### PR TITLE
Adding latency sampling capability to Pktgen

### DIFF
--- a/app/cli-functions.c
+++ b/app/cli-functions.c
@@ -405,7 +405,7 @@ static struct cli_map set_map[] = {
 	{ 70, "set %P cos %d" },
 	{ 80, "set %P tos %d" },
 	{ 90, "set %P vxlan %h %d %d" },
-    { 100, "set %P latsampler %|simple|poisson %d %d %s" },
+    { 100, "set %P latsampler %|uniform|poisson %d %d %d %s" },
 	{ -1, NULL }
 };
 
@@ -449,10 +449,13 @@ static const char *set_help[] = {
 	"set <portlist> cos <value>         - Set the CoS value for the portlist",
 	"set <portlist> tos <value>         - Set the ToS value for the portlist",
 	"set <portlist> vxlan <flags> <group id> <vxlan_id> - Set the vxlan values",
-    "set <portlist> latsampler [simple|poisson] <num-samples> <rate> <outfile>	- Set latency sampler parameters",
-    "		num-samples: number of samples.",
-    "		rate: sampling rate i.e., samples per second.",
-    "		outfile: path to output file to dump all sampled latencies",
+    "set <portlist> latsampler [simple|poisson] <num-samples> <rate> <delay> <outfile>	",
+	"									- Set latency sampler settings for the next packet send",
+	"									- Starts sampling on next tx start, dumps to file on tx stop",
+    "	num-samples: number of samples.",
+    "	rate: sampling rate i.e., samples per second.",
+    "	delay: time to wait (after starting sending packets) before collecting latencies",
+    "	outfile: path to output file to dump all sampled latencies",
 	"set ports_per_page <value>         - Set ports per page value 1 - 6",
 	CLI_HELP_PAUSE,
 	NULL
@@ -467,7 +470,7 @@ set_cmd(int argc, char **argv)
 	struct cli_map *m;
 	struct pg_ipaddr ip;
 	uint16_t id1, id2;
-	uint32_t u1, u2;
+	uint32_t u1, u2, u3;
 	int ip_ver;
 
 	m = cli_mapping(set_map, argc, argv);
@@ -598,7 +601,8 @@ set_cmd(int argc, char **argv)
         case 100:
             u1 = strtol(argv[4], NULL, 0);
             u2 = strtol(argv[5], NULL, 0);
-            foreach_port(portlist, single_set_latsampler_params(info, argv[3], u1, u2, argv[6]));
+            u3 = strtol(argv[6], NULL, 0);
+            foreach_port(portlist, single_set_latsampler_params(info, argv[3], u1, u2, u3, argv[7]));
             break;
 		default:
 			return cli_cmd_error("Command invalid", "Set", argc, argv);
@@ -677,8 +681,6 @@ static struct cli_map start_map[] = {
 	{  20, "stop %P" },
 	{  40, "start %P prime" },
 	{  50, "start %P arp %|request|gratuitous|req|grat" },
-    {  60, "start %P latsampler" },
-    {  70, "stop %P latsampler" },
     { -1, NULL }
 };
 
@@ -691,8 +693,6 @@ static const char *start_help[] = {
 	"start <portlist> prime             - Transmit packets on each port listed. See set prime command above",
 	"start <portlist> arp <type>        - Send a ARP type packet",
 	"    type - request | gratuitous | req | grat",
-    "start <portlist> latsampler        - Start latency sampler, make sure to set sampling parameters before starting",
-    "stop <portlist> latsampler        	- Stop latency sampler, dumps to file if specified",
 	CLI_HELP_PAUSE,
 	NULL
 };
@@ -727,12 +727,6 @@ start_stop_cmd(int argc, char **argv)
 				foreach_port(portlist,
 				     pktgen_send_arp_requests(info, 0) );
 			break;
-        case 60:
-            foreach_port(portlist, pktgen_start_latency_sampler(info));
-            break;
-        case 70:
-            foreach_port(portlist, pktgen_stop_latency_sampler(info));
-            break;
 		default:
 			return cli_cmd_error("Start/Stop command invalid", "Start", argc, argv);
 	}

--- a/app/lpktgenlib.c
+++ b/app/lpktgenlib.c
@@ -2527,7 +2527,7 @@ pktgen_txtap(lua_State *L)
 
 /**************************************************************************//**
  *
- * pktgen_latsampler_params - Set latency sampler params.
+ * pktgen_latsampler_params - Set latency sampler settings.
  *
  * DESCRIPTION
  * Set latency sampler params.
@@ -2544,46 +2544,15 @@ pktgen_latsampler_params(lua_State *L)
 
     switch (lua_gettop(L) ) {
     default: return luaL_error(L, "latsampler_params, wrong number of arguments");
-    case 5:
+    case 6:
         break;
     }
     portlist_parse(luaL_checkstring(L, 1), &portlist);
 
     foreach_port(portlist,
              single_set_latsampler_params(info, (char *)luaL_checkstring(L, 2), 
-                 (uint32_t)luaL_checkinteger(L, 3), (uint32_t)luaL_checkinteger(L, 4), (char *)luaL_checkstring(L, 5)));
-
-    pktgen_update_display();
-    return 0;
-}
-
-
-/**************************************************************************//**
- *
- * pktgen_latsampler - Enable or Disable latency sampler.
- *
- * DESCRIPTION
- * Enable or disable latency sampler.
- *
- * RETURNS: N/A
- *
- * SEE ALSO:
- */
-
-static int
-pktgen_latsampler(lua_State *L)
-{
-    portlist_t portlist;
-
-    switch (lua_gettop(L) ) {
-    default: return luaL_error(L, "latsampler, wrong number of arguments");
-    case 2:
-        break;
-    }
-    portlist_parse(luaL_checkstring(L, 1), &portlist);
-
-    foreach_port(portlist,
-             pktgen_start_stop_latency_sampler(info, estate((char *)luaL_checkstring(L, 2))));
+                 (uint32_t)luaL_checkinteger(L, 3), (uint32_t)luaL_checkinteger(L, 4), 
+				 (uint32_t)luaL_checkinteger(L, 5), (char *)luaL_checkstring(L, 6)));
 
     pktgen_update_display();
     return 0;
@@ -3809,7 +3778,6 @@ static const luaL_Reg pktgenlib[] = {
 	{"txtap",         pktgen_txtap},		/* enable or disable rxtap */
 
     {"latsampler_params",	pktgen_latsampler_params},		/*set latency sampler params */
-    {"latsampler",	pktgen_latsampler},		/* enable or disable latency sampler */
 	
 	{NULL, NULL}
 };

--- a/app/pktgen-cmds.c
+++ b/app/pktgen-cmds.c
@@ -1531,151 +1531,43 @@ void
 pktgen_stop_transmitting(port_info_t *info)
 {
 	uint8_t q;
+    FILE * outfile;
+    uint32_t i, count;
 
 	if (pktgen_tst_port_flags(info, SENDING_PACKETS)) {
 		pktgen_clr_port_flags(info, (SENDING_PACKETS | SEND_FOREVER));
 		for (q = 0; q < get_port_txcnt(pktgen.l2p, info->pid); q++)
 			pktgen_set_q_flags(info, q, DO_TX_FLUSH);
 	}
-}
 
-
-
-/**************************************************************************//**
- *
- * pktgen_start_stop_latency_sampler - Starts or stops latency sampler.
- *
- * DESCRIPTION
- * Starts or stops latency sampler.
- *
- * RETURNS: N/A
- *
- * SEE ALSO:
- */
-
-void
-pktgen_start_stop_latency_sampler(port_info_t *info, uint32_t state)
-{
-    if (state == ENABLE_STATE)
-        pktgen_start_latency_sampler(info);
-    else if (state == DISABLE_STATE)
-        pktgen_stop_latency_sampler(info);
-}
-
-/**************************************************************************//**
- *
- * start_latency_sampler - Starts latency sampler.
- *
- * DESCRIPTION
- * Starts latency sampler.
- *
- * RETURNS: N/A
- *
- * SEE ALSO:
- */
-
-void
-pktgen_start_latency_sampler(port_info_t *info)
-{
-    uint16_t q, rxq;
-
-    /* Start sampler */
+    /* If latency sampling was ON, turn it off and dump collected latencies to file */
     if (pktgen_tst_port_flags(info, SAMPLING_LATENCIES)) {
-        pktgen_log_info("Latency sampler is already running, stop it first!");
-        return;
-    }
+        pktgen_clr_port_flags(info, SAMPLING_LATENCIES);
 
-    if (info->latsamp_rate == 0 || 
-        info->latsamp_outfile == NULL || 
-        info->latsamp_type == LATSAMPLER_UNSPEC ||
-        info->latsamp_num_samples == 0) {
-        pktgen_log_error("Set proper sampling type, number, rate and outfile!");
-        return;
-    }
-
-    rxq = get_port_rxcnt(pktgen.l2p, info->pid);
-    if (rxq == 0 || rxq > MAX_LATENCY_QUEUES) {
-        pktgen_log_error("no rx queues or rx queues over limit (%d) to sample on this port!", MAX_LATENCY_QUEUES);
-        return;
-    }
-
-    for (q = 0; q < rxq; q++) {
-        info->latsamp_stats[q].pkt_counter = 0;
-        info->latsamp_stats[q].next = 0;
-        info->latsamp_stats[q].idx = 0;
-        info->latsamp_stats[q].num_samples = info->latsamp_num_samples / rxq;
-        pktgen_log_info("Assigning %d sample latencies to queue %d", info->latsamp_num_samples / rxq, q);
-    }
-
-    if (info->seq_pkt[SINGLE_PKT].pktSize < (PG_ETHER_MIN_LEN - PG_ETHER_CRC_LEN) + sizeof(tstamp_t))
-        info->seq_pkt[SINGLE_PKT].pktSize += sizeof(tstamp_t);
-
-    info->seq_pkt[SINGLE_PKT].ipProto = PG_IPPROTO_UDP;
-    pktgen_packet_ctor(info, SINGLE_PKT, -1);
-    pktgen_set_tx_update(info);
-
-    /* Start sampling */
-    pktgen_set_port_flags(info, SAMPLING_LATENCIES);
-}
-
-/**************************************************************************//**
- *
- * stop_latency_sampler - Stops latency sampler
- *
- * DESCRIPTION
- * Stops latency sampler
- *
- * RETURNS: N/A
- *
- * SEE ALSO:
- */
-void
-pktgen_stop_latency_sampler(port_info_t *info)
-{
-    FILE * outfile;
-    uint32_t i, count;
-    uint16_t q, rxq = get_port_rxcnt(pktgen.l2p, info->pid);
-
-    if (pktgen_tst_port_flags(info, SAMPLING_LATENCIES) == 0) {
-        pktgen_log_info("Latency sampler is not running, nothing to do!");
-        return;
-    }
-
-    /* Stop sampling */
-    pktgen_clr_port_flags(info, SAMPLING_LATENCIES);
-
-    /* Dump stats to file */
-    outfile = fopen(info->latsamp_outfile, "w");
-    if (outfile == NULL)
-        pktgen_log_error("Cannot open the latcol outfile!");
-    else {
-        pktgen_log_info("Writing to file %s", info->latsamp_outfile);
-        fprintf(outfile, "Latency\n");
-        for (q = 0, count = 0; q < rxq; q++) {
-            pktgen_log_info("Writing sample latencies of queue %d", q);	
-            for (i = 0; i < info->latsamp_stats[q].idx; i++){
-                fprintf(outfile,"%" PRIu64 "\n", info->latsamp_stats[q].data[i]); 
-                count++;
+        /* Dump stats to file */
+        outfile = fopen(info->latsamp_outfile, "w");
+        if (outfile == NULL)
+            pktgen_log_error("Failed to write latencies. Cannot open the latsampler outfile!");
+        else {
+            pktgen_log_info("Writing to file %s", info->latsamp_outfile);
+            fprintf(outfile, "Latency (ns)\n");
+            for (q = 0, count = 0; q < get_port_rxcnt(pktgen.l2p, info->pid); q++) {
+                pktgen_log_info("Writing sample latencies of queue %d", q);	
+                for (i = 0; i < info->latsamp_stats[q].idx; i++){
+                    fprintf(outfile,"%" PRIu64 "\n", info->latsamp_stats[q].data[i]); 
+                    count++;
+                }
             }
+            fclose(outfile);
+            pktgen_log_warning("Wrote %d sampled latencies to file %s", count, info->latsamp_outfile);
         }
-        fclose(outfile);
-        pktgen_log_warning("Wrote %d sample latencies to file %s", count, info->latsamp_outfile);
-    }
+        
+        if (info->seq_pkt[SINGLE_PKT].pktSize >= (PG_ETHER_MIN_LEN - PG_ETHER_CRC_LEN) + sizeof(tstamp_t))
+            info->seq_pkt[SINGLE_PKT].pktSize -= sizeof(tstamp_t);
 
-    /* Reset stats data */
-    for (q = 0; q < rxq; q++) {
-        info->latsamp_stats[q].pkt_counter = 0;
-        info->latsamp_stats[q].next = 0;
-        info->latsamp_stats[q].idx = 0;
-        info->latsamp_stats[q].num_samples = 0;
+        pktgen_packet_ctor(info, SINGLE_PKT, -1);
+        pktgen_set_tx_update(info);
     }
-    
-    if (info->seq_pkt[SINGLE_PKT].pktSize >= (PG_ETHER_MIN_LEN - PG_ETHER_CRC_LEN) + sizeof(tstamp_t))
-        info->seq_pkt[SINGLE_PKT].pktSize -= sizeof(tstamp_t);
-
-    info->seq_pkt[SINGLE_PKT].ipProto = PG_IPPROTO_UDP;
-    pktgen_packet_ctor(info, SINGLE_PKT, -1);
-    pktgen_set_tx_update(info);
 }
 
 /**************************************************************************//**
@@ -2405,23 +2297,24 @@ single_set_vxlan(port_info_t *info, uint16_t flags, uint16_t group_id,
  */
 
 void
-single_set_latsampler_params(port_info_t *info, char* type, uint32_t num_samples, uint32_t sampling_rate, char outfile[])
+single_set_latsampler_params(port_info_t *info, char* type, uint32_t num_samples, uint32_t sampling_rate, uint32_t delay_secs, char outfile[])
 {
     FILE* fp = NULL;
     uint32_t sampler_type;
+    uint16_t q, rxq;
 
-    /* Stop if latency sampler is running */
-    if (pktgen_tst_port_flags(info, SAMPLING_LATENCIES)) {
-        pktgen_log_warning("Latency sampler is already running, stop it first!");
+	if (pktgen_tst_port_flags(info, SENDING_PACKETS)) {
+        pktgen_log_warning("Cannot update latsampler settings while sending packets!");
         return;
-    }
-    /* Validate sampler type*/
-    if (!strcasecmp(type, "simple"))
+	}
+
+    /* Validate sampler type */
+    if (!strcasecmp(type, "uniform"))
         sampler_type = LATSAMPLER_SIMPLE;
     else if (!strcasecmp(type, "poisson"))
         sampler_type = LATSAMPLER_POISSON;
     else {
-        pktgen_log_error("Unknown latsampler type %s! Valid values: simple, poisson", type);
+        pktgen_log_error("Unknown latsampler type %s! Valid values: uniform, poisson", type);
         return;
     }
 
@@ -2433,18 +2326,51 @@ single_set_latsampler_params(port_info_t *info, char* type, uint32_t num_samples
     }
     fclose(fp);
 
-    if (num_samples > MAX_LATENCY_ENTRIES) {
-        pktgen_log_error("Too many samples requested. Max %d!", MAX_LATENCY_ENTRIES);
+    /* Validate sampling settings */
+    if (num_samples == 0 || num_samples > MAX_LATENCY_ENTRIES) {
+        pktgen_log_error("Invalid number of samples requested. Min 1, Max %d!", MAX_LATENCY_ENTRIES);
+        return;
+    }
+    
+    /* Validate sampling settings */
+    if (sampling_rate == 0) {
+        pktgen_log_error("Invalid sampling rate");
+        return;
+    }
+    
+    rxq = get_port_rxcnt(pktgen.l2p, info->pid);
+    if (rxq == 0 || rxq > MAX_LATENCY_QUEUES) {
+        pktgen_log_error("no rx queues or rx queues over the limit (%d) to sample on this port!", MAX_LATENCY_QUEUES);
         return;
     }
 
+    /* Persist settings in port info */
     info->latsamp_type = sampler_type;
     info->latsamp_rate = sampling_rate;
+    info->latsamp_delay = delay_secs;
     info->latsamp_num_samples = num_samples;
     strcpy(info->latsamp_outfile, outfile);
 
+    /* Reset all the counters */
+    for (q = 0; q < rxq; q++) {
+        info->latsamp_stats[q].pkt_counter = 0;
+        info->latsamp_stats[q].next = 0;
+        info->latsamp_stats[q].idx = 0;
+        info->latsamp_stats[q].num_samples = info->latsamp_num_samples / rxq;
+        info->latsamp_stats[q].delay_secs = info->latsamp_delay;
+        pktgen_log_info("Assigning %d sample latencies to queue %d", info->latsamp_num_samples / rxq, q);
+    }
+
+    /* Latency sampler adds an extra timestamp header */
+    if (info->seq_pkt[SINGLE_PKT].pktSize < (PG_ETHER_MIN_LEN - PG_ETHER_CRC_LEN) + sizeof(tstamp_t))
+        info->seq_pkt[SINGLE_PKT].pktSize += sizeof(tstamp_t);
+
+    info->seq_pkt[SINGLE_PKT].ipProto = PG_IPPROTO_UDP;
     pktgen_packet_ctor(info, SINGLE_PKT, -1);
     pktgen_set_tx_update(info);
+
+    /* Start sampling */
+    pktgen_set_port_flags(info, SAMPLING_LATENCIES);
 }
 
 

--- a/app/pktgen-cmds.h
+++ b/app/pktgen-cmds.h
@@ -45,9 +45,6 @@ void pktgen_screen(int state);
 void pktgen_force_update(void);
 void pktgen_update_display(void);
 void pktgen_clear_display(void);
-void pktgen_start_stop_latency_sampler(port_info_t *info, uint32_t state);
-void pktgen_start_latency_sampler(port_info_t *info);
-void pktgen_stop_latency_sampler(port_info_t *info);
 
 int pktgen_save(char *path);
 void pktgen_cls(void);
@@ -93,7 +90,7 @@ void single_set_qinqids(port_info_t *info,
 void single_set_vxlan(port_info_t *info, uint16_t flags,
 		uint16_t group_id, uint32_t vxlan_id);
 void single_set_latsampler_params(port_info_t *info, char* type, 
-		uint32_t num_samples, uint32_t sampling_rate, char outfile[]);	
+		uint32_t num_samples, uint32_t sampling_rate, uint32_t delay_secs, char outfile[]);	
 
 /* Rate */
 char *rate_transmit_count_rate(int port, char *buff, int len);

--- a/app/pktgen-port-cfg.h
+++ b/app/pktgen-port-cfg.h
@@ -31,8 +31,8 @@ extern "C" {
 
 #define MAX_PORT_DESC_SIZE  132
 #define USER_PATTERN_SIZE   16
-#define MAX_LATENCY_ENTRIES 50100		// Max 101000?, limited by max allowed size of latsamp_stats_t.data[]
-#define MAX_LATENCY_QUEUES 	10
+#define MAX_LATENCY_ENTRIES 50100		// Limited by (MAX_LATENCY_QUEUES * MAX_LATENCY_ENTRIES * 64B), size of latsamp_stats_t.data[]
+#define MAX_LATENCY_QUEUES 	10			// Limited by (MAX_LATENCY_QUEUES * MAX_LATENCY_ENTRIES * 64B), size of latsamp_stats_t.data[]
 
 typedef struct port_sizes_s {
 	uint64_t _64;		/**< Number of 64 byte packets */
@@ -196,7 +196,8 @@ typedef struct {
     uint32_t idx;							/**< Index to the latencies array */
     uint64_t next;							/**< Next latency entry */
     uint64_t pkt_counter;					/**< Pkt counter */
-    uint32_t num_samples;
+    uint32_t num_samples;					/**< Number of sampler to be collected on this core/queue */
+	uint32_t delay_secs;					/**< Initial delay in seconds */
 } latsamp_stats_t __rte_cache_aligned;
 
 typedef struct port_info_s {
@@ -314,6 +315,7 @@ typedef struct port_info_s {
     latsamp_stats_t latsamp_stats[MAX_LATENCY_QUEUES];	/**< Per core stats */
     uint32_t latsamp_type;								/**< Type of lat sampler  */
     uint32_t latsamp_rate;								/**< Sampling rate i.e., samples per second  */
+    uint32_t latsamp_delay;								/**< Initial delay in seconds  */
     uint32_t latsamp_num_samples;						/**< Number of samples to collect  */
     char latsamp_outfile[256];							/**< Path to file for dumping latency samples */
 

--- a/app/pktgen.h
+++ b/app/pktgen.h
@@ -393,7 +393,6 @@ void pktgen_input_start(void);
 void stat_timer_dump(void);
 void stat_timer_clear(void);
 void rte_timer_setup(void);
-double next_poisson_time(double rateParameter);
 
 typedef struct {
 	uint64_t timestamp;


### PR DESCRIPTION
Hi,

I have recently added a couple of features (the first of which is this pull request) while using pktgen in our experiments. I don't see any earlier pull requests for this repository, do you not accept code changes from external contributors? I was really hoping these features could help others, I know that they helped at least a couple of my colleagues for their own projects. 

### Our use case
We used pktgen to send packets that are received in the same app either on the same or a different host, and we need to take some samples of latencies for **some** of those packets and save it to a file (only some because at high rates it's not really practical (nor it is needed) to capture latencies of all packets). I've seen the latency testing feature but it only shows the aggregated statistics in the UI whereas, in most cases, users/researchers might need proper latency distributions.

### Commands
`set <portlist> latsampler [simple|poisson] <num-samples> <rate> <outfile>`
`start <port> latsampler`
`stop <port> latsampler`

### How it works
User sets sampler parameters like sampling type (currently uniform and poisson are supported), total number of samples to collect, sampling rate and output file to write to when done. The user starts the sampler which then sets timestamp headers on all the packets going out. On receiving packets, sampler decides whether to sample and saves latencies in an array, until enough samples are collected. When user stops the sampler, these latencies are dumped to the output file.

### Misc
- This change does not have any UI component
- Integrated with Lua as well
- Willing to do address comments and do some extra testing if the change does not meet the bar.
- Another feature where I added capability for pktgen to send packets in different configurations (for e.g., targeted at different applications in the network), and be able to record both throughput and latency separately for each of these configurations is in the queue. I'll push it if this one gets in. 
