### PR TITLE
tcp/udp: set ipv4 version_ihl so checksum is valid

### DIFF
--- a/app/pktgen-tcp.c
+++ b/app/pktgen-tcp.c
@@ -37,6 +37,7 @@ pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void * hdr, int type)
 		ipv4->src_addr = htonl(pkt->ip_src_addr.addr.ipv4.s_addr);
 		ipv4->dst_addr = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
 
+		ipv4->version_ihl = (IPv4_VERSION << 4) | (sizeof(struct pg_ipv4_hdr) / 4);
 		tlen = pkt->pktSize - pkt->ether_hdr_size;
 		ipv4->total_length = htons(tlen);
 		ipv4->next_proto_id = pkt->ipProto;

--- a/app/pktgen-udp.c
+++ b/app/pktgen-udp.c
@@ -37,6 +37,7 @@ pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type)
 		ipv4->src_addr = htonl(pkt->ip_src_addr.addr.ipv4.s_addr);
 		ipv4->dst_addr = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
 
+		ipv4->version_ihl = (IPv4_VERSION << 4) | (sizeof(struct pg_ipv4_hdr) / 4);
 		tlen = pkt->pktSize - pkt->ether_hdr_size;
 		ipv4->total_length = htons(tlen);
 		ipv4->next_proto_id = pkt->ipProto;


### PR DESCRIPTION
Both protocols call rte_ipv4_udptcp_cksum() to build a L4 checksum. That
function calls rte_ipv4_hdr_len() to get the header length and subtracts
that value from the L3 length to determine the L4 length. It looks like
this code was last modified in October 2020.

I believe the existing code was not setting the ipv4 ihl field before
calling rte_ipv4_udptcp_cksum(). On my system with default settings,
the version_ihl byte is 0x6f which means the header length is 60 bytes,
the L3 length is 46, so the L4 length is -14. Thus no checksum is
computed.

With this change, I see valid checksums on 64 byte packets using TCP and
UDP under IPv4.