### PR TITLE
pktgen: fixes for scripting, mtu

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -27,9 +27,9 @@ if get_option('enable_gui')
     cflags += '-DGUI'
 endif
 
-deps += [cc.find_library('rte_net_i40e', required: true)]
-deps += [cc.find_library('rte_net_ixgbe', required: true)]
-deps += [cc.find_library('rte_net_ice', required: true)]
+deps += [cc.find_library('rte_net_i40e', required: false)]
+deps += [cc.find_library('rte_net_ixgbe', required: false)]
+deps += [cc.find_library('rte_net_ice', required: false)]
 
 deps += [dependency('threads')]
 deps += [cc.find_library('numa', required: true)]

--- a/app/pktgen-display.c
+++ b/app/pktgen-display.c
@@ -141,6 +141,11 @@ theme_color_map_t theme_color_map[] = {
 void
 display_topline(const char *msg)
 {
+	if (this_scrn && this_scrn->type != SCRN_STDIN_TYPE) {
+		scrn_puts("\n");
+		return;
+	}
+
 	pktgen_display_set_color("top.page");
 	scrn_printf(1, 20, "%s", msg);
 	pktgen_display_set_color("top.copyright");
@@ -153,6 +158,11 @@ void
 display_dashline(int last_row)
 {
 	int i;
+
+	if (this_scrn && this_scrn->type != SCRN_STDIN_TYPE) {
+		scrn_puts("\n");
+		return;
+	}
 
 	scrn_setw(last_row);
 	last_row--;
@@ -174,6 +184,7 @@ pktgen_display_set_geometry(uint16_t rows, uint16_t cols)
 {
 	if (!this_scrn)
 		return;
+
 	this_scrn->nrows = rows;
 	this_scrn->ncols = cols;
 }
@@ -412,6 +423,9 @@ void
 pktgen_print_div(uint32_t row_first, uint32_t row_last, uint32_t col)
 {
 	uint32_t row;
+
+	if (this_scrn && this_scrn->type != SCRN_STDIN_TYPE)
+		return;
 
 	pktgen_display_set_color("stats.colon");
 	for (row = row_first; row < row_last; row++)

--- a/app/pktgen-display.c
+++ b/app/pktgen-display.c
@@ -407,3 +407,13 @@ pktgen_theme_save(char *filename)
 	fchmod(fileno(f), 0666);
 	fclose(f);
 }
+
+void
+pktgen_print_div(uint32_t row_first, uint32_t row_last, uint32_t col)
+{
+	uint32_t row;
+
+	pktgen_display_set_color("stats.colon");
+	for (row = row_first; row < row_last; row++)
+		scrn_printf(row, col, ":");
+}

--- a/app/pktgen-display.h
+++ b/app/pktgen-display.h
@@ -171,6 +171,19 @@ void pktgen_theme_state(const char *state);
  */
 void pktgen_theme_show(void);
 
+/**************************************************************************//**
+ *
+ * pktgen_print_div - Draw the column divider with colons
+ *
+ * DESCRIPTION
+ * Draw the column divider with colons.
+ *
+ * RETURNS: N/A
+ *
+ * SEE ALSO:
+ */
+void pktgen_print_div(uint32_t row_first, uint32_t row_last, uint32_t col);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/pktgen-latency.c
+++ b/app/pktgen-latency.c
@@ -86,9 +86,8 @@ pktgen_print_static_data(void)
 	display_dashline(pktgen.last_row);
 
 	/* Display the colon after the row label. */
-	pktgen_display_set_color("stats.colon");
-	for (row = PORT_STATE_ROW; row < ((ip_row + IP_ADDR_ROWS) - 2); row++)
-		scrn_printf(row, COLUMN_WIDTH_0 - 1, ":");
+	pktgen_print_div(PORT_STATE_ROW, (ip_row + IP_ADDR_ROWS) - 2,
+			 COLUMN_WIDTH_0 - 1);
 
 	pktgen_display_set_color("stats.stat.values");
 	sp = pktgen.starting_port;

--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -294,6 +294,19 @@ pktgen_config_ports(void)
 		if (pktgen.verbose)
 			rte_eth_dev_info_dump(NULL, pid);
 
+		if (pktgen.eth_mtu < info->dev_info.min_mtu) {
+		    pktgen_log_info("Increasing MTU from %u to %u",
+				    pktgen.eth_mtu, info->dev_info.min_mtu);
+		    pktgen.eth_mtu = info->dev_info.min_mtu;
+		    pktgen.eth_max_pkt = info->dev_info.min_mtu + RTE_ETHER_HDR_LEN;
+		}
+		if (pktgen.eth_mtu > info->dev_info.max_mtu) {
+		    pktgen_log_info("Reducing MTU from %u to %u",
+				    pktgen.eth_mtu, info->dev_info.max_mtu);
+		    pktgen.eth_mtu = info->dev_info.max_mtu;
+		    pktgen.eth_max_pkt = info->dev_info.max_mtu + RTE_ETHER_HDR_LEN;
+		}
+
 		/* Get a clean copy of the configuration structure */
 		rte_memcpy(&conf, &default_port_conf, sizeof(struct rte_eth_conf));
 

--- a/app/pktgen-range.c
+++ b/app/pktgen-range.c
@@ -320,10 +320,8 @@ pktgen_print_range(void)
 	pktgen.last_row = ++row;
 	display_dashline(pktgen.last_row);
 
-	pktgen_display_set_color("stats.colon");
 	/* Display the colon after the row label. */
-	for (row = 3; row < (pktgen.last_row - 1); row++)
-		scrn_printf(row, col_0 - 1, ":");
+	pktgen_print_div(3, pktgen.last_row - 1, col_0 - 1);
 
 	sp = pktgen.starting_port;
 	for (pid = 0; pid < pktgen.nb_ports_per_page; pid++) {

--- a/app/pktgen-rate.c
+++ b/app/pktgen-rate.c
@@ -191,9 +191,8 @@ rate_print_static_data(void)
 	display_dashline(pktgen.last_row);
 
 	/* Display the colon after the row label. */
-	pktgen_display_set_color("stats.colon");
-	for (row = PORT_STATE_ROW; row < ((ip_row + IP_ADDR_ROWS) - 2); row++)
-		scrn_printf(row, COLUMN_WIDTH_0 - 1, ":");
+	pktgen_print_div(PORT_STATE_ROW, (ip_row + IP_ADDR_ROWS) - 2,
+			 COLUMN_WIDTH_0 - 1);
 
 	pktgen_display_set_color("stats.stat.values");
 	sp = pktgen.starting_port;

--- a/app/pktgen-stats.c
+++ b/app/pktgen-stats.c
@@ -121,9 +121,7 @@ pktgen_print_static_data(void)
     display_dashline(pktgen.last_row);
 
     /* Display the colon after the row label. */
-    pktgen_display_set_color("stats.colon");
-    for (row = PORT_STATE_ROW; row < (uint32_t)(pktgen.last_row - 2); row++)
-        scrn_printf(row, COLUMN_WIDTH_0 - 1, ":");
+    pktgen_print_div(PORT_STATE_ROW, pktgen.last_row - 2, COLUMN_WIDTH_0 - 1);
 
     sp          = pktgen.starting_port;
     display_cnt = 0;

--- a/lib/cli/cli.c
+++ b/lib/cli/cli.c
@@ -852,6 +852,8 @@ cli_execute_cmdfile(const char *filename)
 
 	gb_reset_buf(this_cli->gb);
 
+	cli_printf("\nExecuting '%s'\n", filename);
+
 	if (strstr(filename, ".lua") || strstr(filename, ".LUA") ) {
 		if (!this_cli->user_state) {
 			cli_printf(">>> User State for CLI not set for Lua\n");
@@ -872,10 +874,10 @@ cli_execute_cmdfile(const char *filename)
 			return -1;
 
 		/* Read and feed the lines to the cmdline parser. */
-    while (fgets(buff, sizeof(buff), fd)) {
-        cli_input(buff, strlen(buff));
-        memset(buff, 0, sizeof(buff));
-    }
+		while (fgets(buff, sizeof(buff), fd)) {
+			cli_input(buff, strlen(buff));
+			memset(buff, 0, sizeof(buff));
+		}
 
 		fclose(fd);
 	}

--- a/lib/cli/cli_scrn.c
+++ b/lib/cli/cli_scrn.c
@@ -160,46 +160,62 @@ scrn_create(int scrn_type, int theme)
 	struct cli_scrn *scrn = this_scrn;
 	struct sigaction sa;
 
-	memset(&sa, 0, sizeof(struct sigaction));
-	sa.sa_handler = handle_winch;
-	sigaction(SIGWINCH, &sa, NULL);
-
 	if (!scrn) {
 		scrn = calloc(1, sizeof(struct cli_scrn));
 		if (!scrn)
 			return -1;
+
+		memset(scrn, 0, sizeof(*scrn));
 
 		this_scrn = scrn;
 	}
 
 	rte_atomic32_set(&scrn->pause, SCRN_SCRN_PAUSED);
 
-	ioctl(0, TIOCGWINSZ, &w);
-
-	scrn->nrows = w.ws_row;
-	scrn->ncols = w.ws_col;
 	scrn->theme = theme;
 	scrn->type  = scrn_type;
 
 	if (scrn_type == SCRN_STDIN_TYPE) {
+		memset(&sa, 0, sizeof(struct sigaction));
+		sa.sa_handler = handle_winch;
+		sigaction(SIGWINCH, &sa, NULL);
+
+		ioctl(0, TIOCGWINSZ, &w);
+
+		scrn->nrows = w.ws_row;
+		scrn->ncols = w.ws_col;
+
 		if (scrn_stdin_setup()) {
-			free(scrn);
-			return -1;
+			goto err_exit;
 		}
+	} else if (scrn_type == SCRN_NOTTY_TYPE) {
+		scrn->nrows = 24;
+		scrn->ncols = 80;
+
+		scrn_set_io(stdin, stdout);
 	} else {
-		free(scrn);
-		return -1;
+		fprintf(stderr, "%s: unexpected scrn_type %d\n",
+			__func__, scrn_type);
+		goto err_exit;
 	}
 
 	scrn_color(SCRN_DEFAULT_FG, SCRN_DEFAULT_BG, SCRN_OFF);
 
 	return 0;
+
+err_exit:
+	this_scrn = NULL;
+	free(scrn);
+	return -1;
 }
 
 int
 scrn_create_with_defaults(int theme)
 {
-	return scrn_create(SCRN_STDIN_TYPE,
+	int scrn_type =
+		isatty(STDIN_FILENO) ? SCRN_STDIN_TYPE : SCRN_NOTTY_TYPE;
+
+	return scrn_create(scrn_type,
 	                   (theme)? SCRN_THEME_ON : SCRN_THEME_OFF);
 }
 

--- a/lib/cli/cli_scrn.c
+++ b/lib/cli/cli_scrn.c
@@ -147,7 +147,7 @@ handle_winch(int sig)
 	this_scrn->nrows = w.ws_row;
 	this_scrn->ncols = w.ws_col;
 
-	/* Need to refreash the screen */
+	/* Need to refresh the screen */
 	//cli_clear_screen();
 	cli_clear_line(-1);
 	cli_redisplay_line();

--- a/lib/cli/cli_scrn.h
+++ b/lib/cli/cli_scrn.h
@@ -135,6 +135,7 @@ struct vt100_cmds {
 
 /* Add more defines for new types */
 #define SCRN_STDIN_TYPE		0
+#define SCRN_NOTTY_TYPE		1
 
 /** Structure to hold information about the screen and control access. */
 struct cli_scrn {
@@ -230,7 +231,16 @@ void scrn_cprintf(int16_t r, int16_t ncols, const char *fmt, ...);
 void scrn_printf(int16_t r, int16_t c, const char *fmt, ...);
 void scrn_fprintf(int16_t r, int16_t c, FILE *f, const char *fmt, ...);
 
-#define _s(_x, _y)	static __inline__ void _x { _y; }
+#define _s(_x, _y)						       \
+	static __inline__ void					       \
+	_x							       \
+	{							       \
+		if (this_scrn && this_scrn->type == SCRN_STDIN_TYPE) { \
+			_y;					       \
+		} else {					       \
+			scrn_puts("\n");			       \
+		}						       \
+	}
 
 /** position cursor to row and column */
 _s(scrn_pos(int r, int c),  scrn_puts(vt100_pos, r, c))

--- a/lib/cli/cli_scrn.h
+++ b/lib/cli/cli_scrn.h
@@ -262,7 +262,7 @@ _s(scrn_restore(void), scrn_puts("\0338"))
 /** Clear from cursor to end of line */
 _s(scrn_eol(void), scrn_puts("\033[K"))
 
-/** Clear from cursor to begining of line */
+/** Clear from cursor to beginning of line */
 _s(scrn_cbl(void), scrn_puts("\033[1K"))
 
 /** Clear entire line */
@@ -271,10 +271,10 @@ _s(scrn_cel(void), scrn_puts("\033[2K"))
 /** Clear from cursor to end of screen */
 _s(scrn_clw(void), scrn_puts("\033[J"))
 
-/** Clear from cursor to begining of screen */
+/** Clear from cursor to beginning of screen */
 _s(scrn_clb(void), scrn_puts("\033[1J"))
 
-/** Clear the screen, more cursor to home */
+/** Clear the screen, move cursor to home */
 _s(scrn_cls(void), scrn_puts("\033[2J"))
 
 /** Start reverse video */
@@ -298,7 +298,7 @@ _s(scrn_nlines(int r), scrn_puts("\033[%dE", r))
 /** Set window size, from to end of screen */
 _s(scrn_setw(int t), scrn_puts("\033[%d;r", t))
 
-/** Cursor postion report */
+/** Cursor position report */
 _s(scrn_cpos(void), scrn_puts("\033[6n"))
 
 /** Cursor move right <n> characters */
@@ -316,7 +316,7 @@ _s(scrn_cright(void), scrn_puts("\033[C"))
 /** Move one character left */
 _s(scrn_cleft(void), scrn_puts("\033[D"))
 
-/** Move cursor to begining of line */
+/** Move cursor to beginning of line */
 _s(scrn_bol(void), scrn_puts("\r"))
 
 /** Return the version string */


### PR DESCRIPTION
This set of changes allow pktgen to run without a tty. This was useful for us to incorporate pktgen into our existing automated test framework. I recommend turning the screen off when using this mode.
```
pktgen.screen("off") 
```

One change fixes up an MTU issue. I can split that out into a separate PR if you would prefer.

Signed-off-by: Andrew Boyer <aboyer@pensando.io>