### PR TITLE
fix:  function pktmbuf_reset set wrong mbuf->pkt_len

### DIFF
--- a/lib/common/mbuf.h
+++ b/lib/common/mbuf.h
@@ -28,15 +28,13 @@ union pktgen_data {
 static inline void
 pktmbuf_reset(struct rte_mbuf *m)
 {
-	union pktgen_data d;
-
-	d.udata = m->udata64;	/* Save the original value */
+	union pktgen_data *d = (union pktgen_data *)&m->udata64;
 
 	rte_pktmbuf_reset(m);
 
-	m->data_len = d.data_len;
-	m->pkt_len = d.pkt_len;
-	m->buf_len = d.buf_len;
+	m->data_len = d->data_len;
+	m->pkt_len = d->pkt_len;
+	m->buf_len = d->buf_len;
 }
 
 /**


### PR DESCRIPTION
dpdk remove the mbuf->udata64 in new version, pktgen use dynfield1[0] to instead,
but dynfield1's type is uint32_t, When executing this code:
   d.udata = m->udata64,
the d.pkt_len will not be assigned correct value, This will cause the igb driver to be
unable to send out the data.
dpdk igb driver:
eth_igb_xmit_pkts:  txd->read.olinfo_status is not correct.

related issue:
no traffic generated (Pktgen 21.01.2 + DPDK 20.11.0) #51