### PR TITLE
pcap: ensure mempool is a multiple of pcap length

### DIFF
--- a/app/pktgen-pcap.c
+++ b/app/pktgen-pcap.c
@@ -349,10 +349,9 @@ pktgen_pcap_parse(pcap_info_t *pcap, port_info_t *info, unsigned qid)
 
 		_pcap_rewind(pcap);
 
-		/* Round up the count and size to allow for TX ring size. */
+		/* Scale small pcaps so mempool size is close to MAX_MBUFS_PER_PORT. */
 		if (elt_count < MAX_MBUFS_PER_PORT)
-			elt_count = MAX_MBUFS_PER_PORT;
-		elt_count = rte_align32pow2(elt_count);
+			elt_count = (MAX_MBUFS_PER_PORT / elt_count) * elt_count;
 
 		scrn_printf(0, 0, "\r    Create: %-*s   \b", 16, name);
 		info->q[qid].pcap_mp = rte_mempool_create(


### PR DESCRIPTION
Currently, the pcap mempool contains 4,096 mbufs for pcaps <= 4,096
packets. The pcap is copied until every mbuf is filled even if this
results in a partial pcap at the end. Likewise large pcaps create a
mempool that is the next power of 2 with packets copied until the
mempool is full - again with a possible partial pcap at the end.

In my testing, I was checking for specific behavior and metrics after
one or more complete loops of the pcap file. Having the mempool size
not be a multiple of the pcap size shifted the metrics. To me, it makes
more sense to always have the mempool size be a multiple of the pcap
size.

This commit proposes a compromise. Small pcaps < MAX_MBUFS_PER_PORT
will be copied an integer number of times to get as close to
MAX_MBUFS_PER_PORT as possible. This should avoid frequent small burst writes.
Larger pcaps are not extended so the mempool shares the pcap size.