### PR TITLE
pcap: use pcap max packet len to size mempool

### DIFF
--- a/app/pktgen-pcap.c
+++ b/app/pktgen-pcap.c
@@ -307,8 +307,8 @@ int
 pktgen_pcap_parse(pcap_info_t *pcap, port_info_t *info, unsigned qid)
 {
 	pcaprec_hdr_t hdr;
-	uint32_t elt_count, data_size, len, i;
-	uint64_t pkt_sizes = 0;
+	uint32_t elt_count, max_pkt_size, len, i;
+	uint64_t data_size, pkt_sizes = 0;
 	char buffer[DEFAULT_MBUF_SIZE];
 	char name[RTE_MEMZONE_NAMESIZE];
 
@@ -320,7 +320,7 @@ pktgen_pcap_parse(pcap_info_t *pcap, port_info_t *info, unsigned qid)
 	snprintf(name, sizeof(name), "%-12s%d:%d", "PCAP TX", info->pid, qid);
 	scrn_printf(0, 0, "    Process: %-*s ", 18, name);
 
-	pkt_sizes = elt_count = i = 0;
+	pkt_sizes = elt_count = max_pkt_size = i = 0;
 
 	/* The pcap_open left the file pointer to the first packet. */
 	while (_pcap_read(pcap, &hdr, buffer, sizeof(buffer)) > 0) {
@@ -338,6 +338,9 @@ pktgen_pcap_parse(pcap_info_t *pcap, port_info_t *info, unsigned qid)
 			scrn_printf(1, 1, "%c\b", "-\\|/"[i++ & 3]);
 
 		pkt_sizes += len;
+
+		if (len > max_pkt_size)
+			max_pkt_size = len;
 	}
 
 	/* If count is greater then zero then we allocate and create the PCAP mbuf pool. */
@@ -349,15 +352,18 @@ pktgen_pcap_parse(pcap_info_t *pcap, port_info_t *info, unsigned qid)
 
 		_pcap_rewind(pcap);
 
-		/* Scale small pcaps so mempool size is close to MAX_MBUFS_PER_PORT. */
+		/* Repeat small pcaps so mempool size is close to MAX_MBUFS_PER_PORT. */
 		if (elt_count < MAX_MBUFS_PER_PORT)
 			elt_count = (MAX_MBUFS_PER_PORT / elt_count) * elt_count;
+
+		/* Compute final size of each mbuf by adding the structure header and headroom. */
+		max_pkt_size += sizeof(struct rte_mbuf) + RTE_PKTMBUF_HEADROOM;
 
 		scrn_printf(0, 0, "\r    Create: %-*s   \b", 16, name);
 		info->q[qid].pcap_mp = rte_mempool_create(
 		                name,
 		                elt_count,
-		                DEFAULT_MBUF_SIZE,
+		                max_pkt_size,
 		                0,
 		                sizeof(struct rte_pktmbuf_pool_private),
 		                rte_pktmbuf_pool_init,
@@ -371,7 +377,7 @@ pktgen_pcap_parse(pcap_info_t *pcap, port_info_t *info, unsigned qid)
 			pktgen_log_panic("Cannot init port %d for %d PCAP packets",
 					 info->pid, pcap->pkt_count);
 
-		data_size = (pcap->pkt_count * DEFAULT_MBUF_SIZE);
+		data_size = ((uint64_t)pcap->pkt_count * max_pkt_size);
 		scrn_printf(0, 0,
 			"    Create: %-*s - Number of MBUFs %6u for %5d packets                 = %6u KB\n",
 			16,


### PR DESCRIPTION
The pcap module creates a memory pool where each element is sized to hold a jumbo frame. Therefore the memory requirement is dependent on the number of packets in the pcap and not the size of the packets.

This change determines the largest packet in the pcap and sizes the mempool elements based on that value. This can dramatically increase the number of packets that be loaded (dependent on the size of the packets of course). This patch allowed me to load multi-million packet files that panicked pktgen using the standard `DEFAULT_MBUF_SIZE` configuration.

I did have some trouble reducing the `elt_size` value in the call to `rte_mempool_create()`. When using a value that was equal to the maximum pcap `len + RTE_PKTMBUF_HEADROOM` I would see `bus error` then the program terminated (on certain files). I traced the abort to the `pktgen_pcap_mbuf_ctor()` call and the `rte_memcpy()` specifically. That certainly suggested writing out of bounds.

When searching, I found references that `rte_mempool_create()` has been deprecated or is considered legacy. I believe that is not specified in the current (21.05) sources, but the alternative is `rte_pktmbuf_pool_create()` which unfortunately does not have a per-object callback. My belief is backwards-compatibility has been broken within DPDK.

The call to `rte_pktmbuf_data_room_size(mp)` inside `pktgen_pcap_mbuf_ctor()` accesses the private space of the pool using a `rte_pktmbuf_pool_private` structure. This struct is initialized to the `data_room_size` value from the user in `rte_pktmbuf_pool_create_by_ops()` for mempools created using `rte_pktmbuf_pool_create()`. However, when using `rte_mempool_create()` the structure is initialized from passing `rte_pktmbuf_pool_init()` in the call. Pktgen is passing that function a NULL argument, so `rte_pktmbuf_pool_init()` subtracts the size of a `struct rte_mbuf` from the `mp->elt_size` and saves that value in the private pool structure. So the pktgen buffer was ending up short on bytes.

Once I added `sizeof(struct rte_mbuf)` to the element size provided to `rte_mempool_create()`, files loaded and ran successfully. I haven't dug down to see if this is a change of behavior, or if the original `DEFAULT_MBUF_SIZE` was large enough to mask the issue. I find it useful to increase the number of packets loaded into RAM and hope others do as well.