### PR TITLE
fix: Use info->stats.tx_failed to record number of tx retries

### DIFF
--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -332,6 +332,9 @@ pktgen_send_burst(port_info_t *info, uint16_t qid)
 		if (tap)
 			pktgen_do_tx_tap(info, pkts, ret);
 
+		if (cnt - ret)
+			info->stats.tx_failed += (cnt - ret);
+
 		pkts += ret;
 		cnt -= ret;
 	}


### PR DESCRIPTION
when rte_eth_tx_burst fails, record the number of entries the tx ring was overrun.
This is useful in scenarios where pktgen is run in a virtual environment, where this counter can be used to reduce the TX rate to get consistent results.