### PR TITLE
Missing deps fix

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -30,6 +30,7 @@ endif
 deps += [cc.find_library('rte_net_i40e', required: false)]
 deps += [cc.find_library('rte_net_ixgbe', required: false)]
 deps += [cc.find_library('rte_net_ice', required: false)]
+deps += [cc.find_library('rte_bus_vdev', required: false)]
 
 deps += [dependency('threads')]
 deps += [cc.find_library('numa', required: true)]

--- a/lib/cli/meson.build
+++ b/lib/cli/meson.build
@@ -17,6 +17,6 @@ sources = files(
 	'cli_search.c',
 	'cli_vt100.c')
 libcli = library('cli', sources,
-	dependencies: [common, utils])
+	dependencies: [common, utils, dpdk])
 cli = declare_dependency(link_with: libcli,
 	include_directories: include_directories('.'))

--- a/lib/plugin/meson.build
+++ b/lib/plugin/meson.build
@@ -3,6 +3,6 @@
 
 sources = files('plugin.c')
 libplugin = library('plugin', sources,
-	dependencies: common)
+	dependencies: [common, dpdk])
 plugin = declare_dependency(link_with: libplugin,
 	include_directories: include_directories('.'))

--- a/lib/utils/meson.build
+++ b/lib/utils/meson.build
@@ -6,6 +6,6 @@ sources = files(
 	'portlist.c',
 	'heap.c')
 libutils = library('utils', sources,
-	dependencies: common)
+	dependencies: [common, dpdk])
 utils = declare_dependency(link_with: libutils,
 	include_directories: include_directories('.'))

--- a/lib/vec/meson.build
+++ b/lib/vec/meson.build
@@ -3,6 +3,6 @@
 
 sources = files('vec.c')
 libvec = library('vec', sources,
-	dependencies: utils)
+	dependencies: [utils, dpdk])
 vec = declare_dependency(link_with: libvec,
 	include_directories: include_directories('.'))


### PR DESCRIPTION
A few deps are missing from the meson.build files.

First, headers are not found in the lib subdirs if they are not located in the default location.

Second, in latest DPDPK, an additional library is needed when linking the app.