### PR TITLE
pktgen: Fix setting user pattern from cli

### DIFF
--- a/app/cli-functions.c
+++ b/app/cli-functions.c
@@ -652,7 +652,7 @@ set_cmd(int argc, char **argv)
 			break;
 		case 25:
 			foreach_port(portlist,
-				 pattern_set_user_pattern(info, argv[3]));
+				 pattern_set_user_pattern(info, argv[4]));
 			break;
 		case 30:
 			p = strchr(argv[4], '/');


### PR DESCRIPTION
When setting the user pattern from the pktgen cli, it would always be
incorrectly set to the string 'pattern' regardless of input.

This can be demonstrated simply by setting a pattern

    set 0 pattern user
    set 0 user pattern asdfasdf

Signed-off-by: Josh Knight <joshua.knight@netscout.com>