### PR TITLE
Fix compile error on arm64

### DIFF
--- a/app/pktgen-port-cfg.h
+++ b/app/pktgen-port-cfg.h
@@ -32,7 +32,7 @@ extern "C" {
 #define MAX_PORT_DESC_SIZE 132
 #define USER_PATTERN_SIZE  16
 #define MAX_LATENCY_ENTRIES \
-    50100        // Max 101000?, limited by max allowed size of latsamp_stats_t.data[]
+    50108        // Max 101000?, limited by max allowed size of latsamp_stats_t.data[]
 #define MAX_LATENCY_QUEUES 10
 
 typedef struct port_sizes_s {


### PR DESCRIPTION
Currently, pktgen fails to compile on arm64 with the following message:

```
../app/pktgen-port-cfg.h:309:5: error: size of array element is not a multiple of its alignment
```

This is because sizeof(latsamp_stats_t) is divisible by 64, but not 128 (RTE_CACHE_LINE_SIZE is 64 on x86_64 and arm32, but 128 on arm64). This PR makes sizeof(latsamp_stats_t) divisible by 128, fixing compilation on arm64. I confirmed that pktgen still builds on x86_64 with this patch as well.