### PR TITLE
Fix missing dependency for fgen

### DIFF
--- a/lib/fgen/meson.build
+++ b/lib/fgen/meson.build
@@ -3,5 +3,5 @@
 
 sources = files('fgen.c', 'parse.c', 'unparse.c')
 
-libfgen = library('ften', sources, dependencies: common)
+libfgen = library('ften', sources, dependencies: [common, dpdk])
 fgen = declare_dependency(link_with: libfgen, include_directories: include_directories('.'))


### PR DESCRIPTION
Hi,

Similar to #85, `fgen` also depends on `dpdk`. 
To build `pktgen-dpdk` with non-standard header locations,
this patch adds `dpdk` dependency for `fgen`.

Thanks