### PR TITLE
Improve rate management

### DIFF
--- a/app/pktgen-stats.c
+++ b/app/pktgen-stats.c
@@ -479,7 +479,7 @@ pktgen_page_stats(void)
  * SEE ALSO:
  */
 void
-pktgen_process_stats(struct rte_timer *tim __rte_unused, void *arg __rte_unused)
+pktgen_process_stats(double elapsed_ns)
 {
     unsigned int pid;
     struct rte_eth_stats *curr, *rate, *prev, *base;
@@ -533,17 +533,15 @@ pktgen_process_stats(struct rte_timer *tim __rte_unused, void *arg __rte_unused)
         rate = &info->rate_stats;
         prev = &info->prev_stats;
 
-        rate->ipackets  = curr->ipackets - prev->ipackets;
-        rate->opackets  = curr->opackets - prev->opackets;
-        rate->ibytes    = curr->ibytes - prev->ibytes;
-        rate->obytes    = curr->obytes - prev->obytes;
-        rate->ierrors   = curr->ierrors - prev->ierrors;
-        rate->oerrors   = curr->oerrors - prev->oerrors;
-        rate->imissed   = curr->imissed - prev->imissed;
-        rate->rx_nombuf = curr->rx_nombuf - prev->rx_nombuf;
+        rate->ipackets  = (((curr->ipackets - prev->ipackets) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->opackets  = (((curr->opackets - prev->opackets) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->ibytes    = (((curr->ibytes - prev->ibytes) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->obytes    = (((curr->obytes - prev->obytes) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->ierrors   = (((curr->ierrors - prev->ierrors) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->oerrors   = (((curr->oerrors - prev->oerrors) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->imissed   = (((curr->imissed - prev->imissed) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->rx_nombuf = (((curr->rx_nombuf - prev->rx_nombuf) * Billion) / elapsed_ns) + ROUND_FACTOR;
 
-        if (rate->ipackets > 0xffffffff)
-            printf("%ld %ld > %ld\n", base->ipackets, curr->ipackets, prev->ipackets);
         /* Find the new max rate values */
         if (rate->ipackets > info->max_ipackets)
             info->max_ipackets = rate->ipackets;

--- a/app/pktgen-stats.h
+++ b/app/pktgen-stats.h
@@ -32,7 +32,7 @@ typedef struct pkt_stats_s {
 struct port_info_s;
 
 void pktgen_get_link_status(struct port_info_s *info, int pid, int wait);
-void pktgen_process_stats(struct rte_timer *tim, void *arg);
+void pktgen_process_stats(double elapsed_ns);
 
 void pktgen_page_stats(void);
 void pktgen_page_phys_stats(uint16_t pid);

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -1305,7 +1305,7 @@ pktgen_main_rxtx_loop(uint8_t lid)
 
         /* Determine when is the next time to send packets */
         if (curr_tsc >= tx_next_cycle) {
-            tx_next_cycle = curr_tsc + infos[0]->tx_cycles;
+            tx_next_cycle = tx_next_cycle + infos[0]->tx_cycles;
 
             for (idx = 0; idx < txcnt; idx++) /* Transmit packets */
                 pktgen_main_transmit(infos[idx], qids[idx]);
@@ -1397,7 +1397,7 @@ pktgen_main_tx_loop(uint8_t lid)
 
         /* Determine when is the next time to send packets */
         if (curr_tsc >= tx_next_cycle) {
-            tx_next_cycle = curr_tsc + infos[0]->tx_cycles;
+            tx_next_cycle = tx_next_cycle + infos[0]->tx_cycles;
 
             for (idx = 0; idx < txcnt; idx++) /* Transmit packets */
                 pktgen_main_transmit(infos[idx], qids[idx]);

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -95,7 +95,7 @@ pktgen_packet_rate(port_info_t *info)
 {
     uint64_t wire_size = (pktgen_wire_size(info) * 8);
     uint64_t lk        = (uint64_t)info->link.link_speed * Million;
-    uint64_t pps       = ((lk / wire_size) * info->tx_rate) / 100;
+    uint64_t pps       = (((lk / wire_size) * info->tx_rate) / 100) + ROUND_FACTOR;
     uint64_t cpp       = (pps > 0) ? (pktgen.hz / pps) : pktgen.hz;
 
     info->tx_pps    = pps;

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -415,7 +415,7 @@ pktgen_recv_tstamp(port_info_t *info, struct rte_mbuf **pkts, uint16_t nb_pkts)
                         if (stats->idx < stats->num_samples) {
                             // stats->data[stats->idx] = lat;
                             stats->data[stats->idx] =
-                                lat * 1000000000 /
+                                (lat * Billion) /
                                 rte_get_tsc_hz(); /* Do we want to keep it as cycles? */
                             stats->idx++;
                         }
@@ -1558,7 +1558,7 @@ _page_display(void)
  */
 
 void
-pktgen_page_display(struct rte_timer *tim __rte_unused, void *arg __rte_unused)
+pktgen_page_display()
 {
     static unsigned int update_display = 1;
 
@@ -1590,27 +1590,29 @@ pktgen_page_display(struct rte_timer *tim __rte_unused, void *arg __rte_unused)
 static void *
 _timer_thread(void *arg)
 {
-    uint64_t process, page, process_timo, page_timo;
+    uint64_t process, page, process_timo, page_timo, prev;
 
     this_scrn = arg;
 
     process_timo = pktgen.hz;
     page_timo    = UPDATE_DISPLAY_TICK_RATE;
 
-    page    = rte_get_tsc_cycles();
+    page = prev = rte_get_tsc_cycles();
     process = page + process_timo;
     page += page_timo;
 
     pktgen.timer_running = 1;
 
     while (pktgen.timer_running) {
-        uint64_t curr;
+        uint64_t curr, elapsed_ns;
 
         curr = rte_get_tsc_cycles();
 
         if (curr >= process) {
             process = curr + process_timo;
-            pktgen_process_stats(NULL, NULL);
+            elapsed_ns = (curr - prev) * Billion / pktgen.hz;
+            prev = curr;
+            pktgen_process_stats(elapsed_ns);
         }
 
         if (curr >= page) {

--- a/app/pktgen.h
+++ b/app/pktgen.h
@@ -108,6 +108,7 @@ extern "C" {
 #define MAX_STRING         256
 #define ROUND_FACTOR       0.5
 #define Million            (uint64_t)(1000000ULL)
+#define Billion            (uint64_t)(1000000000ULL)
 
 #define iBitsTotal(_x) (uint64_t)(((_x.ipackets * PKT_OVERHEAD_SIZE) + _x.ibytes) * 8)
 #define oBitsTotal(_x) (uint64_t)(((_x.opackets * PKT_OVERHEAD_SIZE) + _x.obytes) * 8)
@@ -364,7 +365,7 @@ enum {                                  /* Pktgen flags bits */
 
 extern pktgen_t pktgen;
 
-void pktgen_page_display(struct rte_timer *tim, void *arg);
+void pktgen_page_display();
 
 void pktgen_packet_ctor(port_info_t *info, int32_t seq_idx, int32_t type);
 void pktgen_packet_rate(port_info_t *info);

--- a/app/pktgen.h
+++ b/app/pktgen.h
@@ -106,6 +106,7 @@ extern "C" {
 
 #define MAX_MATRIX_ENTRIES 128
 #define MAX_STRING         256
+#define ROUND_FACTOR       0.5
 #define Million            (uint64_t)(1000000ULL)
 
 #define iBitsTotal(_x) (uint64_t)(((_x.ipackets * PKT_OVERHEAD_SIZE) + _x.ibytes) * 8)


### PR DESCRIPTION
This PR contains 3 commits to improve how rate is enforced and measured.

- c70af30 correctly rounds the value of pps when computing rate (instead of truncating it). This could be annoying when setting low rates (e.g. on a 40Gbps NIC setting rate 0.000168% resulted in 99 pps instead of the expected 100).
- bd3e615 takes into account the delay that incurs when computing the next tx cycle value (due to the time needed to actually send packets). This resulted in waiting longer than the expected `tx_cycle` before the next transmission, producing a lower throughput, especially visible with a low burst size. With a 40 Gbps NIC, setting 16.8% rate (expected 10 Mpps) and a burst of 1 pkt I formerly achieved only 9.41 Mpps while now I correctly get 10 Mpps.
- 41c15eb handles a similar problem when computing rate stats. Since the time between two computations is usually bigger then the desired 1 second, rates are usually higher as well. With this commit the actual time elapsed since the last update is used to compute the rate.

Hope this fixes are useful and formatted correctly. Please let me know if there is some improvement I can make.