### PR TITLE
Prevent overflow when computing rate stats

### DIFF
--- a/app/pktgen-stats.c
+++ b/app/pktgen-stats.c
@@ -479,7 +479,7 @@ pktgen_page_stats(void)
  * SEE ALSO:
  */
 void
-pktgen_process_stats(double elapsed_ns)
+pktgen_process_stats(double rel_delay)
 {
     unsigned int pid;
     struct rte_eth_stats *curr, *rate, *prev, *base;
@@ -533,14 +533,14 @@ pktgen_process_stats(double elapsed_ns)
         rate = &info->rate_stats;
         prev = &info->prev_stats;
 
-        rate->ipackets  = (((curr->ipackets - prev->ipackets) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->opackets  = (((curr->opackets - prev->opackets) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->ibytes    = (((curr->ibytes - prev->ibytes) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->obytes    = (((curr->obytes - prev->obytes) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->ierrors   = (((curr->ierrors - prev->ierrors) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->oerrors   = (((curr->oerrors - prev->oerrors) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->imissed   = (((curr->imissed - prev->imissed) * Billion) / elapsed_ns) + ROUND_FACTOR;
-        rate->rx_nombuf = (((curr->rx_nombuf - prev->rx_nombuf) * Billion) / elapsed_ns) + ROUND_FACTOR;
+        rate->ipackets  = ((curr->ipackets - prev->ipackets) / rel_delay) + ROUND_FACTOR;
+        rate->opackets  = ((curr->opackets - prev->opackets) / rel_delay) + ROUND_FACTOR;
+        rate->ibytes    = ((curr->ibytes - prev->ibytes) / rel_delay) + ROUND_FACTOR;
+        rate->obytes    = ((curr->obytes - prev->obytes) / rel_delay) + ROUND_FACTOR;
+        rate->ierrors   = ((curr->ierrors - prev->ierrors) / rel_delay) + ROUND_FACTOR;
+        rate->oerrors   = ((curr->oerrors - prev->oerrors) / rel_delay) + ROUND_FACTOR;
+        rate->imissed   = ((curr->imissed - prev->imissed) / rel_delay) + ROUND_FACTOR;
+        rate->rx_nombuf = ((curr->rx_nombuf - prev->rx_nombuf) / rel_delay) + ROUND_FACTOR;
 
         /* Find the new max rate values */
         if (rate->ipackets > info->max_ipackets)

--- a/app/pktgen-stats.h
+++ b/app/pktgen-stats.h
@@ -32,7 +32,7 @@ typedef struct pkt_stats_s {
 struct port_info_s;
 
 void pktgen_get_link_status(struct port_info_s *info, int pid, int wait);
-void pktgen_process_stats(double elapsed_ns);
+void pktgen_process_stats(double rel_delay);
 
 void pktgen_page_stats(void);
 void pktgen_page_phys_stats(uint16_t pid);

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -1604,15 +1604,14 @@ _timer_thread(void *arg)
     pktgen.timer_running = 1;
 
     while (pktgen.timer_running) {
-        uint64_t curr, elapsed_ns;
+        uint64_t curr;
 
         curr = rte_get_tsc_cycles();
 
         if (curr >= process) {
             process = curr + process_timo;
-            elapsed_ns = (curr - prev) * Billion / pktgen.hz;
+            pktgen_process_stats((double)(curr - prev) / process_timo);
             prev = curr;
-            pktgen_process_stats(elapsed_ns);
         }
 
         if (curr >= page) {


### PR DESCRIPTION
Using elapsed ns to compute rate stats could lead to overflow when operating with 400 Gbps NICs.
If the NIC is going at full speed the operation `obytes * Billion` could result in `5e10 * 1e9 = 5e19` that is higher than the max value of a `uint64_t`.
Moreover computing the number of elapsed ns is not necessary (and a bit stupid :( ) since we only need the ratio between the actual time elapsed and the expected one (1 s) that is the same as the ratio of elapsed clock cycles.
I updated the code to use that value.
Sorry but I just realized this after the former PR was merged.