### PR TITLE
Fix RISC-V builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,10 @@ pktgen_conf = configuration_data()
 # set up some global vars for compiler, platform, configuration, etc.
 cc = meson.get_compiler('c')
 
-add_project_arguments('-march=native', language: 'c')
+target = target_machine.cpu_family()
+if (target != 'riscv64')
+    add_project_arguments('-march=native', language: 'c')
+endif
 
 if get_option('enable-avx') and cc.has_argument('-mavx')
     add_project_arguments('-mavx', language: 'c')


### PR DESCRIPTION
Building on RISC-V results in an error

    cc: error: ‘-march=native’: ISA string must begin with rv32 or rv64

As GCC does not support -march=native on RISC-V avoid this argument.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>