### PR TITLE
Update rfc2544 script, Fixed a confirmation trial bug

### DIFF
--- a/scripts/rfc2544.lua
+++ b/scripts/rfc2544.lua
@@ -481,7 +481,7 @@ local function runThroughputTest(pkt_size)
 
 		-- confirm throughput rate for at least 60 seconds
 		num_dropped = runTrial(pkt_size, trial_rate, confirmDuration, "Final", 0);
-		loss_limit = (sent*loss_tol);
+		
 		printLine();
 		if num_dropped <= loss_limit
 		then


### PR DESCRIPTION
Fixed an incorrect calculated loss_limit in the confirmation trial run.
loss_limit is already set correctly from runTrial() 