### PR TITLE
Make build more adaptable with various DPDK setup

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -31,10 +31,10 @@ if get_option('enable_gui')
     cflags += '-DGUI'
 endif
 
-deps += [cc.find_library('rte_net_i40e', required: false)]
-deps += [cc.find_library('rte_net_ixgbe', required: false)]
-deps += [cc.find_library('rte_net_ice', required: false)]
-deps += [cc.find_library('rte_bus_vdev', required: false)]
+deps += [cc.find_library('rte_net_i40e', dirs: [dpdk_libs_path], required: false)]
+deps += [cc.find_library('rte_net_ixgbe', dirs: [dpdk_libs_path], required: false)]
+deps += [cc.find_library('rte_net_ice', dirs: [dpdk_libs_path], required: false)]
+deps += [cc.find_library('rte_bus_vdev', dirs: [dpdk_libs_path], required: false)]
 
 deps += [dependency('threads')]
 deps += [cc.find_library('numa', required: true)]


### PR DESCRIPTION
Sometimes user can config dpdk installed in non default
location, pktgen install need to ways to find rte_net_xxx like
rte_net_bond. Or else, it could not find them correctly.

Signed-off-by: Kaiqiang Wu <kaiqiang.wu@intel.com>