### PR TITLE
fixed clang compile errors

### DIFF
--- a/app/pktgen-cmds.c
+++ b/app/pktgen-cmds.c
@@ -1545,7 +1545,7 @@ pktgen_start_latency_sampler(port_info_t *info)
         return;
     }
 
-    if (info->latsamp_rate == 0 || info->latsamp_outfile == NULL ||
+    if (info->latsamp_rate == 0 ||
         info->latsamp_type == LATSAMPLER_UNSPEC || info->latsamp_num_samples == 0) {
         pktgen_log_error("Set proper sampling type, number, rate and outfile!");
         return;

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -675,7 +675,7 @@ pktgen_packet_ctor(port_info_t *info, int32_t seq_idx, int32_t type)
         *((uint32_t *)&arp->arp_data.arp_sha) = htonl(pkt->ip_src_addr.addr.ipv4.s_addr);
 
         rte_ether_addr_copy(&pkt->eth_dst_addr, (struct rte_ether_addr *)&arp->arp_data.arp_tha);
-        *((uint32_t *)&arp->arp_data.arp_tip) = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
+        *((uint32_t *)((void*)&arp->arp_data + offsetof(struct rte_arp_ipv4,arp_tip))) = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
     } else
         pktgen_log_error("Unknown EtherType 0x%04x", pkt->ethType);
 }
@@ -1619,7 +1619,7 @@ _timer_thread(void *arg)
 
         if (curr >= page) {
             page = curr + page_timo;
-            pktgen_page_display(NULL, NULL);
+            pktgen_page_display();
         }
 
         rte_pause();

--- a/lib/cli/cli.h
+++ b/lib/cli/cli.h
@@ -238,7 +238,7 @@ struct cli_tree {
 #define c_file(n, rw, h)	{ CLI_FILE_NODE,  .file = {(n), (rw), (h)} }
 #define c_alias(n, l, h)	{ CLI_ALIAS_NODE, .alias = {(n), (l), (h)} }
 #define c_str(n, f, s)		{ CLI_STR_NODE,   .str = {(n), (f), (s)} }
-#define c_end()			{ CLI_UNK_NODE,   .dir = { NULL } }
+#define c_end()			{ CLI_UNK_NODE,   .dir = { NULL, 0 } }
 
 static inline void
 cli_set_user_state(void *val)

--- a/lib/fgen/fgen.c
+++ b/lib/fgen/fgen.c
@@ -70,13 +70,13 @@ fgen_add_frame(fgen_t *fg, const char *name, const char *fstr)
     if (_add_frame(fg, fg->nb_frames, name, fstr) < 0)
         _ERR_RET("Failed to parse frame\n");
 
-    if (fg->flags & (FGEN_VERBOSE || FGEN_DUMP_DATA))
+    if (fg->flags & (FGEN_VERBOSE | FGEN_DUMP_DATA))
         printf("\n");
 
     return 0;
 }
 
-static __rte_always_inline void
+__rte_always_inline void
 _prefetch_mbuf_data(struct rte_mbuf *m, uint32_t hdr_len)
 {
     uint8_t *pkt_data = rte_pktmbuf_mtod(m, uint8_t *);


### PR DESCRIPTION
There are several legitamate erros that `clang` gives that `gcc` does not. It's a bit of a hack doing

```bash
sed '/werror=true/d' -i meson.build
```

To make the software compile. **I did not test to see if these changes work** as I'm still a beginner at DPDK.

# Dump of clang compile errors pre fix

```
[14/52] Compiling C object 'lib/fgen/d6a69e1@@ften@sta/fgen.c.o'.
FAILED: lib/fgen/d6a69e1@@ften@sta/fgen.c.o 
/bin/clang -Ilib/fgen/d6a69e1@@ften@sta -Ilib/fgen -I../lib/fgen -Ilib/common -I../lib/common -I/usr/local/include -I/usr/include/libnl3 -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -march=native -mavx -mavx2 -DALLOW_EXPERIMENTAL_API -D_GNU_SOURCE -Wno-pedantic -fPIC -include rte_config.h -march=native -MD -MQ 'lib/fgen/d6a69e1@@ften@sta/fgen.c.o' -MF 'lib/fgen/d6a69e1@@ften@sta/fgen.c.o.d' -o 'lib/fgen/d6a69e1@@ften@sta/fgen.c.o' -c ../lib/fgen/fgen.c
../lib/fgen/fgen.c:73:35: error: converting the enum constant to a boolean [-Werror,-Wint-in-bool-context]
    if (fg->flags & (FGEN_VERBOSE || FGEN_DUMP_DATA))
                                  ^
1 error generated.
[17/52] Compiling C object 'lib/cli/ec45a30@@cli@sta/cli_cmds.c.o'.
FAILED: lib/cli/ec45a30@@cli@sta/cli_cmds.c.o 
/bin/clang -Ilib/cli/ec45a30@@cli@sta -Ilib/cli -I../lib/cli -Ilib/common -I../lib/common -Ilib/utils -I../lib/utils -I/usr/local/include -I/usr/include/libnl3 -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -march=native -mavx -mavx2 -DALLOW_EXPERIMENTAL_API -D_GNU_SOURCE -Wno-pedantic -fPIC -include rte_config.h -march=native -MD -MQ 'lib/cli/ec45a30@@cli@sta/cli_cmds.c.o' -MF 'lib/cli/ec45a30@@cli@sta/cli_cmds.c.o.d' -o 'lib/cli/ec45a30@@cli@sta/cli_cmds.c.o' -c ../lib/cli/cli_cmds.c
../lib/cli/cli_cmds.c:680:1: error: missing field 'bin' initializer [-Werror,-Wmissing-field-initializers]
c_end()
^
../lib/cli/cli.h:241:51: note: expanded from macro 'c_end'
#define c_end()                 { CLI_UNK_NODE,   .dir = { NULL } }
                                                                ^
1 error generated.
[21/52] Compiling C object 'app/a172ced@@pktgen@exe/cli-functions.c.o'.
FAILED: app/a172ced@@pktgen@exe/cli-functions.c.o 
/bin/clang -Iapp/a172ced@@pktgen@exe -Iapp -I../app -Ilib/common -I../lib/common -Ilib/utils -I../lib/utils -Ilib/vec -I../lib/vec -Ilib/plugin -I../lib/plugin -Ilib/cli -I../lib/cli -Ilib/lua -I../lib/lua -I/usr/local/include -I/usr/include/libnl3 -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -march=native -mavx -mavx2 -DALLOW_EXPERIMENTAL_API -D_GNU_SOURCE -Wno-pedantic -pthread -include rte_config.h -march=native '-D__PROJECT_VERSION="22.07.0"' -MD -MQ 'app/a172ced@@pktgen@exe/cli-functions.c.o' -MF 'app/a172ced@@pktgen@exe/cli-functions.c.o.d' -o 'app/a172ced@@pktgen@exe/cli-functions.c.o' -c ../app/cli-functions.c
../app/cli-functions.c:2115:5: error: missing field 'bin' initializer [-Werror,-Wmissing-field-initializers]
    c_end()};
    ^
../lib/cli/cli.h:241:51: note: expanded from macro 'c_end'
#define c_end()                 { CLI_UNK_NODE,   .dir = { NULL } }
                                                                ^
1 error generated.
[22/52] Compiling C object 'app/a172ced@@pktgen@exe/pktgen-cmds.c.o'.
FAILED: app/a172ced@@pktgen@exe/pktgen-cmds.c.o 
/bin/clang -Iapp/a172ced@@pktgen@exe -Iapp -I../app -Ilib/common -I../lib/common -Ilib/utils -I../lib/utils -Ilib/vec -I../lib/vec -Ilib/plugin -I../lib/plugin -Ilib/cli -I../lib/cli -Ilib/lua -I../lib/lua -I/usr/local/include -I/usr/include/libnl3 -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -march=native -mavx -mavx2 -DALLOW_EXPERIMENTAL_API -D_GNU_SOURCE -Wno-pedantic -pthread -include rte_config.h -march=native '-D__PROJECT_VERSION="22.07.0"' -MD -MQ 'app/a172ced@@pktgen@exe/pktgen-cmds.c.o' -MF 'app/a172ced@@pktgen@exe/pktgen-cmds.c.o.d' -o 'app/a172ced@@pktgen@exe/pktgen-cmds.c.o' -c ../app/pktgen-cmds.c
../app/pktgen-cmds.c:1548:42: error: comparison of array 'info->latsamp_outfile' equal to a null pointer is always false [-Werror,-Wtautological-pointer-compare]
    if (info->latsamp_rate == 0 || info->latsamp_outfile == NULL ||
                                   ~~~~~~^~~~~~~~~~~~~~~    ~~~~
1 error generated.
[26/52] Compiling C object 'app/a172ced@@pktgen@exe/pktgen.c.o'.
FAILED: app/a172ced@@pktgen@exe/pktgen.c.o 
/bin/clang -Iapp/a172ced@@pktgen@exe -Iapp -I../app -Ilib/common -I../lib/common -Ilib/utils -I../lib/utils -Ilib/vec -I../lib/vec -Ilib/plugin -I../lib/plugin -Ilib/cli -I../lib/cli -Ilib/lua -I../lib/lua -I/usr/local/include -I/usr/include/libnl3 -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -march=native -mavx -mavx2 -DALLOW_EXPERIMENTAL_API -D_GNU_SOURCE -Wno-pedantic -pthread -include rte_config.h -march=native '-D__PROJECT_VERSION="22.07.0"' -MD -MQ 'app/a172ced@@pktgen@exe/pktgen.c.o' -MF 'app/a172ced@@pktgen@exe/pktgen.c.o.d' -o 'app/a172ced@@pktgen@exe/pktgen.c.o' -c ../app/pktgen.c
../app/pktgen.c:678:24: error: taking address of packed member 'arp_tip' of class or structure 'rte_arp_ipv4' may result in an unaligned pointer value [-Werror,-Waddress-of-packed-member]
        *((uint32_t *)&arp->arp_data.arp_tip) = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
                       ^~~~~~~~~~~~~~~~~~~~~
../app/pktgen.c:1622:43: error: too many arguments in call to 'pktgen_page_display' [-Werror]
            pktgen_page_display(NULL, NULL);
            ~~~~~~~~~~~~~~~~~~~           ^
2 errors generated.
[27/52] Compiling C object 'app/a172ced@@pktgen@exe/pktgen-main.c.o'.
ninja: build stopped: subcommand failed.
make: *** [Makefile:15: build] Error 1
```