### PR TITLE
Fix run.py error when showing usage

### DIFF
--- a/tools/run.py
+++ b/tools/run.py
@@ -17,7 +17,7 @@ import shutil
 
 def usage():
         '''Print usage information for the program'''
-        argv0 = basename(sys.argv[0])
+        argv0 = os.path.basename(sys.argv[0])
         print("""
 Usage:
 ------


### PR DESCRIPTION
When launching ./tools/run.py with the `-h` option, it shows the folloing error:

```
>>> sdk 'None', target 'None'
Traceback (most recent call last):
  File "./tools/run.py", line 443, in <module>
    main()
  File "./tools/run.py", line 435, in main
    cfg_file = parse_args()
  File "./tools/run.py", line 395, in parse_args
    usage()
  File "./tools/run.py", line 20, in usage
    argv0 = basename(sys.argv[0])
NameError: name 'basename' is not defined
```

This is caused by a missing of module name in line 20, `argv0 = basename(sys.argv[0])` should be `argv0 = os.path.basename(sys.argv[0])` instead.

Signed-off-by: QianHao <qi_an_hao@126.com>