### PR TITLE
add ci to build and deploy doc to gh-pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,5 +26,8 @@ indent_size = 3
 indent_style = space
 indent_size = 4
 
+[*.yml]
+indent_size = 2
+
 [COMMIT_EDITMSG]
 max_line_length = 72

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,39 @@
+name: Doc Deploy
+
+on:
+  push:
+    branches: [dev]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt install python3-sphinx meson ninja-build
+      - name: Build docs
+        run: |
+          meson -Donly_docs=true Builddir
+          make docs
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./Builddir/doc/source/html"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/meson.build
+++ b/meson.build
@@ -63,18 +63,23 @@ if get_option('enable_lua')
 	endif
 endif
 
-dpdk = dependency('libdpdk', required: true)
-# message('prefix: ' + get_option('prefix') + ' libdir: ' + get_option('libdir'))
+if get_option('only_docs')
+	subdir('tools')
+	subdir('doc')
+else
+	dpdk = dependency('libdpdk', required: true)
+	# message('prefix: ' + get_option('prefix') + ' libdir: ' + get_option('libdir'))
 
-dpdk_libs_path = join_paths(get_option('prefix'), get_option('libdir'))
-# message('DPDK lib path: ' + dpdk_libs_path)
+	dpdk_libs_path = join_paths(get_option('prefix'), get_option('libdir'))
+	# message('DPDK lib path: ' + dpdk_libs_path)
 
-dpdk_bond = cc.find_library('librte_net_bond', dirs: [dpdk_libs_path], required: false)
+	dpdk_bond = cc.find_library('librte_net_bond', dirs: [dpdk_libs_path], required: false)
 
-subdir('tools')
+	subdir('tools')
 
-subdir('lib')
+	subdir('lib')
 
-subdir('app')
+	subdir('app')
 
-subdir('doc')
+	subdir('doc')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,4 @@ option('enable_gui', type: 'boolean', value: false, description: 'build the gui'
 option('enable_docs', type: 'boolean', value: false, description: 'build documentation')
 option('enable-avx', type: 'boolean', value: true, description: 'Try to compile with AVX support')
 option('enable-avx2', type: 'boolean', value: true, description: 'Try to compile with AVX2 support')
+option('only_docs', type: 'boolean', value: false, description: 'Only build documentation')


### PR DESCRIPTION
Using GitHub actions and pages to deploy documents.

- Adding option `only_docs` to meson to ignore check of `dpdk`
- Using the `pages deploy from action` feature of GitHub
  - To enable: [Settings] - [Pages] - [Build and deployment] - [Source (select GitHub Actions)]

close #126 

Signed-off-by: Campbell He <kp.campbell.he@duskmoon314.com>