### PR TITLE
Configure the set MTU with DPDK

### DIFF
--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -312,7 +312,12 @@ pktgen_config_ports(void)
 
         pktgen.mem_used = 0;
 
-        for (int q = 0; q < rt.rx; q++) {
+        if ((ret = rte_eth_dev_set_mtu(pid, pktgen.eth_mtu)) < 0) {
+            pktgen_log_panic("Cannot set MTU %u on port %u, (%d)%s", pktgen.eth_mtu, pid,
+                             -ret, rte_strerror(-ret));
+        }
+
+        for (q = 0; q < rt.rx; q++) {
             struct rte_eth_rxconf rxq_conf;
             struct rte_eth_conf conf = {0};
 

--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -312,12 +312,11 @@ pktgen_config_ports(void)
 
         pktgen.mem_used = 0;
 
-        if ((ret = rte_eth_dev_set_mtu(pid, pktgen.eth_mtu)) < 0) {
+        if ((ret = rte_eth_dev_set_mtu(pid, pktgen.eth_mtu)) < 0)
             pktgen_log_panic("Cannot set MTU %u on port %u, (%d)%s", pktgen.eth_mtu, pid,
                              -ret, rte_strerror(-ret));
-        }
 
-        for (q = 0; q < rt.rx; q++) {
+        for (int q = 0; q < rt.rx; q++) {
             struct rte_eth_rxconf rxq_conf;
             struct rte_eth_conf conf = {0};
 


### PR DESCRIPTION
Tested with tags/pktgen-22.07.1 and DPDK 22.07.

Adding the necessary call to ensure MTU is configured. Not sure if there would be a point of allowing Pktgen to run with another MTU value than what the driver has configured, and for that value to be restored when Pktgen exits. In that case, probably save the initial MTU in the `pktgen` struct, and restore it on exit.

Signed-off-by: Andreas K. Berg <andreas.klavenes.berg@cern.ch>