### PR TITLE
increase NUM Qs and new GCC compiler

### DIFF
--- a/app/pktgen-constants.h
+++ b/app/pktgen-constants.h
@@ -28,7 +28,7 @@ enum {
 
     DEFAULT_PRIV_SIZE = 0,
 
-    NUM_Q = 16, /**< Number of queues per port. */
+    NUM_Q = 64, /**< Number of queues per port. */
 };
 #define DEFAULT_MBUF_SIZE                                                                         \
     (PG_JUMBO_FRAME_LEN + RTE_PKTMBUF_HEADROOM) /* See: http://dpdk.org/dev/patchwork/patch/4479/ \

--- a/lib/cli/cli_gapbuf.h
+++ b/lib/cli/cli_gapbuf.h
@@ -367,8 +367,12 @@ gb_expand_buf(struct gapbuf *gb, uint32_t more)
 
 		more = (gb->ebuf - gb->buf) + more + GB_DEFAULT_GAP_SIZE;
 
+#ifdef __GNUC__
+#if GCC_VERSION >= 120200
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
+#endif
 		gb->buf = (char *)realloc(gb->buf, more);
 		if (gb->buf == NULL)
 			rte_panic("realloc(%d) in %s failed\n", more, __func__);
@@ -377,7 +381,12 @@ gb_expand_buf(struct gapbuf *gb, uint32_t more)
 		gb->ebuf    += (gb->buf - old);
 		gb->gap     += (gb->buf - old);
 		gb->egap    += (gb->buf - old);
+#ifdef __GNUC__
+#if GCC_VERSION >= 120200
 #pragma GCC diagnostic pop
+#endif
+#endif
+		gb->buf = (char *)realloc(gb->buf, more);
 	}
 }
 


### PR DESCRIPTION
Increase NUM Qs to 64 instead of 16. Fix the coompiler pragma errors with older GCC compilers then 12.02.0. The GCC 12.02.0 compiler detects a new warning, but the pragma option is not supported in older versions.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>