### PR TITLE
Move the terminal flags backup to RTE_INIT.

### DIFF
--- a/lib/cli/cli_scrn.c
+++ b/lib/cli/cli_scrn.c
@@ -100,11 +100,7 @@ scrn_stdin_setup(void)
 	if (!scrn)
 		return -1;
 
-	scrn_set_io(stdin, stdout);
-
-	memset(&scrn->oldterm, 0, sizeof(term));
-	if (tcgetattr(fileno(scrn->fd_in), &scrn->oldterm) ||
-	    tcgetattr(fileno(scrn->fd_in), &term)) {
+	if (tcgetattr(fileno(scrn->fd_in), &term)) {
 		fprintf(stderr, "%s: setup failed for tty\n", __func__);
 		return -1;
 	}
@@ -232,4 +228,8 @@ RTE_INIT(scrn_constructor)
 	memset(scrn, 0, sizeof(struct cli_scrn));
 
 	this_scrn = scrn;
+
+	scrn_set_io(stdin, stdout);
+	memset(&this_scrn->oldterm, 0, sizeof(struct termios));
+	tcgetattr(fileno(this_scrn->fd_in), &this_scrn->oldterm);
 }


### PR DESCRIPTION
The scrn_stdin_setup() is called twice when the pktgen start:
EAL: Detected NUMA nodes: 1
EAL: Detected shared linkage of DPDK
EAL: Multi-process socket /var/run/dpdk/pktgen/mp_socket
EAL: Selected IOVA mode 'VA'
EAL: Probe PCI driver: mlx5_pci (15b3:1019) device: 0000:01:00.0 (socket 0)
TELEMETRY: No legacy callbacks, legacy socket not created
========scrn_stdin_setup
oldterm: 0x8a3b
Lua 5.3.4  Copyright (C) 1994-2017 Lua.org, PUC-Rio
========scrn_stdin_setup
oldterm: 0xa30

And the oldterm will be backup twice, and actually it is not the origin value when restore back when quit from pktgen. 

The PR moves the oldterm backup into the RTE_INIT , which will only be backup once and avoid the problem. 