### PR TITLE
tty settings not being handle correctly

### DIFF
--- a/app/pktgen-arp.c
+++ b/app/pktgen-arp.c
@@ -188,7 +188,7 @@ pktgen_process_arp(struct rte_mbuf *m, uint32_t pid, uint32_t qid, uint32_t vlan
             m1->ol_flags = 0;
 
             rte_eth_tx_buffer(info->pid, qid, info->q[qid].txbuff, m1);
-
+            rte_eth_tx_buffer_flush(info->pid, qid, info->q[qid].txbuff);
             return;
         }
     } else if (arp->arp_opcode == htons(ARP_REPLY)) {

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -260,6 +260,7 @@ pktgen_tstamp_inject(port_info_t *info, uint16_t qid)
         mbuf->ol_flags = 0;
 
         rte_eth_tx_buffer(info->pid, qid, info->q[qid].txbuff, mbuf);
+        rte_eth_tx_buffer_flush(info->pid, qid, info->q[qid].txbuff);
     } else
         printf("*** No more latency packets\n");
 }


### PR DESCRIPTION
The tty settings were being collected twice on startup and not being restored to the original.
Latency or arp packets not being inject correctly.