### PR TITLE
Destroy screen when exiting on failure

### DIFF
--- a/app/pktgen-log.h
+++ b/app/pktgen-log.h
@@ -81,9 +81,10 @@ extern "C" {
         rte_panic(fmt "\n", ##__VA_ARGS__);                                            \
     } while (0)
 #else
-#define pktgen_log_panic(fmt, ...) do {                                                \
-        scrn_destroy();                                                                \
-        rte_panic(fmt, ##__VA_ARGS__);                                                 \
+#define pktgen_log_panic(fmt, ...)     \
+    do {                               \
+        scrn_destroy();                \
+        rte_panic(fmt, ##__VA_ARGS__); \
     } while(0)
 #endif
 

--- a/app/pktgen-log.h
+++ b/app/pktgen-log.h
@@ -85,7 +85,7 @@ extern "C" {
     do {                               \
         scrn_destroy();                \
         rte_panic(fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 #endif
 
 /* Helper for building log strings.
@@ -98,7 +98,7 @@ extern "C" {
         char _buff[1023];                                      \
         snprintf(_buff, sizeof(_buff), fmt, ##__VA_ARGS__);    \
         strncat(dest, _buff, sizeof(dest) - strlen(dest) - 1); \
-    } while(0)
+    } while (0)
 
 /* Initialize log data structures */
 void pktgen_init_log(void);

--- a/app/pktgen-log.h
+++ b/app/pktgen-log.h
@@ -98,7 +98,7 @@ extern "C" {
         char _buff[1023];                                      \
         snprintf(_buff, sizeof(_buff), fmt, ##__VA_ARGS__);    \
         strncat(dest, _buff, sizeof(dest) - strlen(dest) - 1); \
-    } while (0)
+    } while(0)
 
 /* Initialize log data structures */
 void pktgen_init_log(void);

--- a/app/pktgen-log.h
+++ b/app/pktgen-log.h
@@ -76,11 +76,15 @@ extern "C" {
 #if LOG_LEVEL <= LOG_LEVEL_PANIC
 #define pktgen_log_panic(fmt, ...)                                                     \
     do {                                                                               \
+        scrn_destroy();                                                                \
         pktgen_log(LOG_LEVEL_PANIC, __FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__); \
         rte_panic(fmt "\n", ##__VA_ARGS__);                                            \
     } while (0)
 #else
-#define pktgen_log_panic(fmt, ...) rte_panic(fmt, ##__VA_ARGS__)
+#define pktgen_log_panic(fmt, ...) do {                                                \
+        scrn_destroy();                                                                \
+        rte_panic(fmt, ##__VA_ARGS__);                                                 \
+    } while(0)
 #endif
 
 /* Helper for building log strings.

--- a/app/pktgen-main.c
+++ b/app/pktgen-main.c
@@ -386,6 +386,8 @@ sig_handler(int v __rte_unused)
 
     free(strings);
 
+    scrn_destroy();
+
     exit(-1);
 }
 
@@ -488,6 +490,7 @@ main(int argc, char **argv)
     if (get_lcore_rxcnt(pktgen.l2p, i) || get_lcore_txcnt(pktgen.l2p, i)) {
         cli_printf("*** Error can not use initial lcore for a port\n");
         cli_printf("    The initial lcore is %d\n", rte_get_main_lcore());
+        scrn_destroy();
         exit(-1);
     }
 

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -1171,7 +1171,7 @@ port_map_info(const char *msg, uint8_t lid, port_mapinfo_t *pm)
         pm->rx.pids[i] = get_rx_pid(pktgen.l2p, pm->lid, i);
 
         if ((pm->rx.infos[i] = get_port_private(pktgen.l2p, pm->rx.pids[i])) == NULL)
-            rte_panic("Config error: No port %d found on lcore %d\n", pm->rx.pids[i], pm->lid);
+            pktgen_log_panic("Config error: No port %d found on lcore %d\n", pm->rx.pids[i], pm->lid);
 
         pm->rx.qids[i] = get_rxque(pktgen.l2p, lid, pm->rx.pids[i]);
     }
@@ -1180,7 +1180,7 @@ port_map_info(const char *msg, uint8_t lid, port_mapinfo_t *pm)
         pm->tx.pids[i] = get_tx_pid(pktgen.l2p, pm->lid, i);
 
         if ((pm->tx.infos[i] = get_port_private(pktgen.l2p, pm->tx.pids[i])) == NULL)
-            rte_panic("Config error: No port %d found on lcore %d\n", pm->tx.pids[i], pm->lid);
+            pktgen_log_panic("Config error: No port %d found on lcore %d\n", pm->tx.pids[i], pm->lid);
 
         pm->tx.qids[i] = get_txque(pktgen.l2p, lid, pm->tx.pids[i]);
     }
@@ -1223,14 +1223,14 @@ pktgen_main_rxtx_loop(uint8_t lid)
     pg_start_lcore(pktgen.l2p, lid);
 
     if (pmap.rx.cnt == 0 || pmap.tx.cnt == 0)
-        rte_panic("No ports found for %d lcore\n", lid);
+        pktgen_log_panic("No ports found for %d lcore\n", lid);
 
     if (pktgen.verbose)
         pktgen_log_info("For RX found %d port(s) for lcore %d", pmap.rx.cnt, lid);
 
     for (int i = 0; i < pmap.rx.cnt; i++) {
         if (pmap.rx.infos[i] == NULL)
-            rte_panic("Invalid RX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid RX config: port at index %d not found for %d lcore\n", i, lid);
     }
 
     if (pktgen.verbose)
@@ -1238,7 +1238,7 @@ pktgen_main_rxtx_loop(uint8_t lid)
 
     for (int i = 0; i < pmap.tx.cnt; i++) {
         if (pmap.tx.infos[i] == NULL)
-            rte_panic("Invalid TX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid TX config: port at index %d not found for %d lcore\n", i, lid);
     }
 
     for (int i = 0; i < pmap.rx.cnt; i++) {
@@ -1246,7 +1246,7 @@ pktgen_main_rxtx_loop(uint8_t lid)
         int dev_sock = rte_eth_dev_socket_id(pid);
 
         if (dev_sock != SOCKET_ID_ANY && dev_sock != (int)rte_socket_id())
-            rte_panic(
+            pktgen_log_panic(
                 "*** port %u on socket ID %u has different socket ID than lcore %u socket ID %d\n",
                 pid, rte_eth_dev_socket_id(pid), rte_lcore_id(), rte_socket_id());
     }
@@ -1327,13 +1327,13 @@ pktgen_main_tx_loop(uint8_t lid)
     pg_start_lcore(pktgen.l2p, lid);
 
     if (pmap.tx.cnt == 0)
-        rte_panic("No ports found for %d lcore\n", lid);
+        pktgen_log_panic("No ports found for %d lcore\n", lid);
 
     for (int i = 0; i < pmap.tx.cnt; i++) {
         pktgen_log_info("  Using port/qid %d/%d for Tx on lcore id %d\n", pmap.tx.infos[i]->pid,
                         pmap.tx.qids[i], lid);
         if (pmap.tx.infos[i] == NULL)
-            rte_panic("Invalid TX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid TX config: port at index %d not found for %d lcore\n", i, lid);
     }
 
     for (int i = 0; i < pmap.tx.cnt; i++) {
@@ -1341,7 +1341,7 @@ pktgen_main_tx_loop(uint8_t lid)
         int dev_sock = rte_eth_dev_socket_id(pid);
 
         if (dev_sock != SOCKET_ID_ANY && dev_sock != (int)rte_socket_id())
-            rte_panic("*** port %u on socket ID %u has different socket ID than lcore %u on socket "
+            pktgen_log_panic("*** port %u on socket ID %u has different socket ID than lcore %u on socket "
                       "ID %d\n",
                       pid, rte_eth_dev_socket_id(pid), rte_lcore_id(), rte_socket_id());
     }
@@ -1408,13 +1408,13 @@ pktgen_main_rx_loop(uint8_t lid)
     pg_start_lcore(pktgen.l2p, lid);
 
     if (pmap.rx.cnt == 0)
-        rte_panic("No ports found for %d lcore\n", lid);
+        pktgen_log_panic("No ports found for %d lcore\n", lid);
 
     for (int i = 0; i < pmap.rx.cnt; i++) {
         pktgen_log_info("  Using port/qid %d/%d for Rx on lcore id %d\n", pmap.rx.infos[i]->pid,
                         pmap.rx.qids[i], lid);
         if (pmap.rx.infos[i] == NULL)
-            rte_panic("Invalid RX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid RX config: port at index %d not found for %d lcore\n", i, lid);
     }
 
     for (int i = 0; i < pmap.rx.cnt; i++) {
@@ -1422,7 +1422,7 @@ pktgen_main_rx_loop(uint8_t lid)
         int dev_sock = rte_eth_dev_socket_id(pid);
 
         if (dev_sock != SOCKET_ID_ANY && dev_sock != (int)rte_socket_id())
-            rte_panic(
+            pktgen_log_panic(
                 "*** port %u on socket ID %u has different socket ID than lcore %u socket ID %d\n",
                 pid, rte_eth_dev_socket_id(pid), rte_lcore_id(), rte_socket_id());
     }

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -1171,7 +1171,8 @@ port_map_info(const char *msg, uint8_t lid, port_mapinfo_t *pm)
         pm->rx.pids[i] = get_rx_pid(pktgen.l2p, pm->lid, i);
 
         if ((pm->rx.infos[i] = get_port_private(pktgen.l2p, pm->rx.pids[i])) == NULL)
-            pktgen_log_panic("Config error: No port %d found on lcore %d\n", pm->rx.pids[i], pm->lid);
+            pktgen_log_panic("Config error: No port %d found on lcore %d\n", pm->rx.pids[i],
+                             pm->lid);
 
         pm->rx.qids[i] = get_rxque(pktgen.l2p, lid, pm->rx.pids[i]);
     }
@@ -1180,7 +1181,8 @@ port_map_info(const char *msg, uint8_t lid, port_mapinfo_t *pm)
         pm->tx.pids[i] = get_tx_pid(pktgen.l2p, pm->lid, i);
 
         if ((pm->tx.infos[i] = get_port_private(pktgen.l2p, pm->tx.pids[i])) == NULL)
-            pktgen_log_panic("Config error: No port %d found on lcore %d\n", pm->tx.pids[i], pm->lid);
+            pktgen_log_panic("Config error: No port %d found on lcore %d\n", pm->tx.pids[i],
+                             pm->lid);
 
         pm->tx.qids[i] = get_txque(pktgen.l2p, lid, pm->tx.pids[i]);
     }
@@ -1230,7 +1232,8 @@ pktgen_main_rxtx_loop(uint8_t lid)
 
     for (int i = 0; i < pmap.rx.cnt; i++) {
         if (pmap.rx.infos[i] == NULL)
-            pktgen_log_panic("Invalid RX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid RX config: port at index %d not found for %d lcore\n", i,
+                             lid);
     }
 
     if (pktgen.verbose)
@@ -1238,7 +1241,8 @@ pktgen_main_rxtx_loop(uint8_t lid)
 
     for (int i = 0; i < pmap.tx.cnt; i++) {
         if (pmap.tx.infos[i] == NULL)
-            pktgen_log_panic("Invalid TX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid TX config: port at index %d not found for %d lcore\n", i,
+                             lid);
     }
 
     for (int i = 0; i < pmap.rx.cnt; i++) {
@@ -1333,7 +1337,8 @@ pktgen_main_tx_loop(uint8_t lid)
         pktgen_log_info("  Using port/qid %d/%d for Tx on lcore id %d\n", pmap.tx.infos[i]->pid,
                         pmap.tx.qids[i], lid);
         if (pmap.tx.infos[i] == NULL)
-            pktgen_log_panic("Invalid TX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid TX config: port at index %d not found for %d lcore\n", i,
+                             lid);
     }
 
     for (int i = 0; i < pmap.tx.cnt; i++) {
@@ -1341,9 +1346,10 @@ pktgen_main_tx_loop(uint8_t lid)
         int dev_sock = rte_eth_dev_socket_id(pid);
 
         if (dev_sock != SOCKET_ID_ANY && dev_sock != (int)rte_socket_id())
-            pktgen_log_panic("*** port %u on socket ID %u has different socket ID than lcore %u on socket "
-                      "ID %d\n",
-                      pid, rte_eth_dev_socket_id(pid), rte_lcore_id(), rte_socket_id());
+            pktgen_log_panic(
+                "*** port %u on socket ID %u has different socket ID than lcore %u on socket "
+                "ID %d\n",
+                pid, rte_eth_dev_socket_id(pid), rte_lcore_id(), rte_socket_id());
     }
 
     while (pg_lcore_is_running(pktgen.l2p, lid)) {
@@ -1414,7 +1420,8 @@ pktgen_main_rx_loop(uint8_t lid)
         pktgen_log_info("  Using port/qid %d/%d for Rx on lcore id %d\n", pmap.rx.infos[i]->pid,
                         pmap.rx.qids[i], lid);
         if (pmap.rx.infos[i] == NULL)
-            pktgen_log_panic("Invalid RX config: port at index %d not found for %d lcore\n", i, lid);
+            pktgen_log_panic("Invalid RX config: port at index %d not found for %d lcore\n", i,
+                             lid);
     }
 
     for (int i = 0; i < pmap.rx.cnt; i++) {


### PR DESCRIPTION
When exitting after screen is created, either because of wrong core allocations or due to an internal error, input control was not handed back to the user's terminal.

I simply added a call to `scrn_destroy` wherever applicable (although I couldn't find where the terminal control was supposed to have been taken before `pktgen-main.c:492`), but it might be cleaner in the future to wrap in a custom exit function with a checklist of memory and terminal cleanup.