### PR TITLE
support pkg-config path for cross compile

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -37,8 +37,8 @@ deps += [cc.find_library('rte_net_ice', dirs: [dpdk_libs_path], required: false)
 deps += [cc.find_library('rte_bus_vdev', dirs: [dpdk_libs_path], required: false)]
 
 deps += [dependency('threads')]
-deps += [cc.find_library('numa', required: true)]
-deps += [cc.find_library('pcap', required: true)]
+deps += [dependency('numa', required: true)]
+deps += [dependency('pcap', required: true)]
 deps += [cc.find_library('dl', required: false)]
 deps += [cc.find_library('m', required: false)]
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ pktgen_conf = configuration_data()
 cc = meson.get_compiler('c')
 
 target = target_machine.cpu_family()
-if (target != 'riscv64')
+if (target != 'riscv64') and (target != 'aarch64')
     add_project_arguments('-march=native', language: 'c')
 endif
 
@@ -67,11 +67,11 @@ if get_option('only_docs')
 	subdir('tools')
 	subdir('doc')
 else
-	dpdk = dependency('libdpdk', required: true)
-	# message('prefix: ' + get_option('prefix') + ' libdir: ' + get_option('libdir'))
-
-	dpdk_libs_path = join_paths(get_option('prefix'), get_option('libdir'))
-	# message('DPDK lib path: ' + dpdk_libs_path)
+	dpdk = dependency('libdpdk', required: true, method: 'pkg-config')
+	dpdk_prefix = dpdk.get_pkgconfig_variable('prefix')
+	message('prefix: ' + dpdk_prefix + ' libdir: ' + get_option('libdir'))
+	dpdk_libs_path = join_paths(dpdk_prefix, get_option('libdir'))
+	message('DPDK lib path: ' + dpdk_libs_path)
 
 	dpdk_bond = cc.find_library('librte_net_bond', dirs: [dpdk_libs_path], required: false)
 


### PR DESCRIPTION
In case of cross compile, libraries may be available at non-standard locations. This patch supports to check the pkg-config specified path for some of the mandatory libraries.