### PR TITLE
fix compiler type checking

### DIFF
--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -248,7 +248,7 @@ pktgen_config_ports(void)
         info->seq_pkt = rte_zmalloc_socket(buff, (sizeof(pkt_seq_t) * NUM_TOTAL_PKTS),
                                            RTE_CACHE_LINE_SIZE, rte_socket_id());
         if (info->seq_pkt == NULL)
-            pktgen_log_panic("Unable to allocate %ld pkt_seq_t headers", NUM_TOTAL_PKTS);
+            pktgen_log_panic("Unable to allocate %ld pkt_seq_t headers", (long int)NUM_TOTAL_PKTS);
 
         for (int i = 0; i < NUM_TOTAL_PKTS; i++) {
             info->seq_pkt[i].seq_enabled = 1;


### PR DESCRIPTION
Some compilers do not like %ld in this change, so cast it to the correct version. 
gcc (Ubuntu 12.3.0-1ubuntu1~23.04) 12.3.0