### PR TITLE
Fix tstamp pointer alignment

### DIFF
--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -218,18 +218,15 @@ pktgen_find_matching_ipdst(port_info_t *info, uint32_t addr)
 static __inline__ tstamp_t *
 pktgen_tstamp_pointer(port_info_t *info, char *p)
 {
-    char *ptr;
-
     (void)info;
+    int offset = 0;
 
-    p += sizeof(struct rte_ether_hdr);
-    p += sizeof(struct rte_ipv4_hdr);
-    p += sizeof(struct rte_udp_hdr);
+    offset += sizeof(struct rte_ether_hdr);
+    offset += sizeof(struct rte_ipv4_hdr);
+    offset += sizeof(struct rte_udp_hdr);
+    offset = (offset + sizeof(uint64_t)) & ~(sizeof(uint64_t) - 1);
 
-    /* Force pointer to be aligned correctly */
-    ptr = RTE_PTR_ALIGN_CEIL(p, sizeof(uint64_t));
-
-    return (tstamp_t *)ptr;
+    return (tstamp_t *)(p + offset);
 }
 
 static inline void


### PR DESCRIPTION
The original implementation is only correct if `p % 8` yields a constant value, which is not always the case. Let's consider the following examples:

- On the tx side, if `p = 0x10047c3c0`, then `0x10047c3c0 + 14 + 20 + 8 = 0x10047c3ea`. This aligns to `0x10047c3f0`, resulting in an offset of `0x10047c3f0 - 0x10047c3c0 = 48`.
- On the rx side, if `p = 0x10ebb10c2`, then `0x10ebb10c2 + 14 + 20 + 8 = 0x10ebb10ec`. This aligns to `0x10ebb10f0`, resulting in an offset of `0x10ebb10f0 - 0x10ebb10c2 = 46`.

The discrepancy in offsets within the packet prevents the rx side from correctly detecting the magic number.

The corrected implementation calculates the offset independent from the original value of p. 