### PR TITLE
Fix parameter when invoking pktgen_main_receive

### DIFF
--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -1256,7 +1256,7 @@ pktgen_main_rxtx_loop(uint8_t lid)
         for (int i = 0; i < pmap.rx.cnt; i++) {
             port_info_t *info = pmap.rx.infos[i];
 
-            pktgen_main_receive(info, lid, pkts_burst, info->tx_burst);
+            pktgen_main_receive(info, lid, pkts_burst, info->rx_burst);
         }
 
         curr_tsc = pktgen_get_time();


### PR DESCRIPTION
I think we should pass `rx_burst` to `pktgen_main_receive`, since this function handles packet reception. 
Otherwise, the command `set <portlist> txburst <value>` might unintentionally affect the receive behavior in Pktgen.
