### PR TITLE
config rx offloads based on dev capa

### DIFF
--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -235,6 +235,8 @@ pktgen_config_ports(void)
             pinfo->lsc_enabled = 1;
         }
 
+        conf.rxmode.offloads &= pinfo->dev_info.rx_offload_capa;
+
         if ((ret = rte_eth_dev_configure(pid, l2p_get_rxcnt(pid), l2p_get_txcnt(pid), &conf)) < 0)
             pktgen_log_panic("Cannot configure device: port=%d, Num queues %d,%d", pid,
                              l2p_get_rxcnt(pid), l2p_get_txcnt(pid));


### PR DESCRIPTION
Some devices (for example gve, Google Virtuel Ethernet) does not have capabilities of default rx offloads RTE_ETH_RX_OFFLOAD_CHECKSUM which ends up dev config failure.
So use device capabilities before actual configuration.