### PR TITLE
Fix when use pktgen.seqTable() or  pktgen.seq() in lua script

### DIFF
--- a/app/lpktgenlib.c
+++ b/app/lpktgenlib.c
@@ -65,7 +65,7 @@ pktgen_get_portlist(lua_State *L, int index)
     portlist_t portlist;
 
     if (lua_isstring(L, index)) {
-        if (portlist_parse(luaL_checkstring(L, 1), pktgen.nb_ports, &portlist) < 0)
+        if (portlist_parse(luaL_checkstring(L, index), pktgen.nb_ports, &portlist) < 0)
             portlist = INVALID_PORTLIST;
     } else if (lua_isnumber(L, index))
         portlist = (uint64_t)lua_tonumber(L, index);


### PR DESCRIPTION
When I use test/test_seq.lua，only update the first seqTable success.
pktgen.seqTable(1, '0', seq_table[1]); 
This bug occurs when the second argument is of type string.
