### PR TITLE
fix Lua build with DPDK release 25.03

### DIFF
--- a/lib/lua/lua_dpdk.c
+++ b/lib/lua/lua_dpdk.c
@@ -35,10 +35,6 @@ int luaopen_dapi(lua_State *L);
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
 
-#ifndef __rte_weak
-#define __rte_weak __attribute__((__weak__))
-#endif
-
 static int lua_logtype;
 
 static __inline__ void
@@ -409,7 +405,7 @@ luaopen_dpdk(lua_State *L)
     return 1;
 }
 
-__rte_weak int
+__attribute__((__weak__)) int
 luaopen_dapi(lua_State *L __rte_unused)
 {
     return 0;


### PR DESCRIPTION
[DPDK release 25.03](https://doc.dpdk.org/guides/rel_notes/release_25_03.html) [deprecates the `__rte_weak` macro](https://github.com/DPDK/dpdk/blob/7246d0a80cb79a04e1334393ef507aa4ef7accd9/lib/eal/include/rte_common.h#L182-L186). This in turn results in error when compiling Pktgen-DPDK with `buildlua` and the currently used warning options. This macro is only used in a single place in the codebase, so I suggest the simple fix in this PR which will also keep backwards compatibility with older releases of DPDK.