### PR TITLE
Checksum offloading changes to support GVE GQ

### DIFF
--- a/app/pktgen-ipv4.c
+++ b/app/pktgen-ipv4.c
@@ -30,7 +30,7 @@
  */
 
 void
-pktgen_ipv4_ctor(pkt_seq_t *pkt, void *hdr)
+pktgen_ipv4_ctor(pkt_seq_t *pkt, void *hdr, bool cksum_offload)
 {
     struct rte_ipv4_hdr *ip = hdr;
     uint16_t tlen;
@@ -54,7 +54,8 @@ pktgen_ipv4_ctor(pkt_seq_t *pkt, void *hdr)
     ip->src_addr        = htonl(pkt->ip_src_addr.addr.ipv4.s_addr);
     ip->dst_addr        = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
     ip->hdr_checksum    = 0;
-    ip->hdr_checksum    = rte_ipv4_cksum((const struct rte_ipv4_hdr *)ip);
+    if (!cksum_offload)
+        ip->hdr_checksum = rte_ipv4_cksum((const struct rte_ipv4_hdr *)ip);
 }
 
 /**

--- a/app/pktgen-ipv4.h
+++ b/app/pktgen-ipv4.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-void pktgen_ipv4_ctor(pkt_seq_t *pkt, void *hdr);
+void pktgen_ipv4_ctor(pkt_seq_t *pkt, void *hdr, bool cksum_offload);
 void pktgen_send_ping4(uint32_t pid, uint8_t seq_idx);
 void pktgen_process_ping4(struct rte_mbuf *m, uint32_t pid, uint32_t qid, uint32_t vlan);
 

--- a/app/pktgen-tcp.c
+++ b/app/pktgen-tcp.c
@@ -25,7 +25,7 @@
  */
 
 void *
-pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type)
+pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload)
 {
     uint16_t tlen;
 
@@ -53,7 +53,9 @@ pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type)
         tcp->tcp_urp   = 0;
 
         tcp->cksum = 0;
-        tcp->cksum = rte_ipv4_udptcp_cksum(ipv4, (const void *)tcp);
+        if (!cksum_offload)
+            tcp->cksum = rte_ipv4_udptcp_cksum(ipv4, (const void *)tcp);
+
     } else {
         struct rte_ipv6_hdr *ipv6 = (struct rte_ipv6_hdr *)hdr;
         struct rte_tcp_hdr *tcp   = (struct rte_tcp_hdr *)&ipv6[1];
@@ -79,7 +81,8 @@ pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type)
         tcp->tcp_urp   = 0;
 
         tcp->cksum = 0;
-        tcp->cksum = rte_ipv6_udptcp_cksum(ipv6, (const void *)tcp);
+        if (!cksum_offload)
+            tcp->cksum = rte_ipv6_udptcp_cksum(ipv6, (const void *)tcp);
     }
 
     /* In this case we return the original value to allow IP ctor to work */

--- a/app/pktgen-tcp.h
+++ b/app/pktgen-tcp.h
@@ -28,7 +28,7 @@ extern "C" {
  * SEE ALSO:
  */
 
-void *pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type);
+void *pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload);
 
 #ifdef __cplusplus
 }

--- a/app/pktgen-udp.h
+++ b/app/pktgen-udp.h
@@ -30,7 +30,7 @@ extern "C" {
  * SEE ALSO:
  */
 
-void *pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type);
+void *pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload);
 
 #ifdef __cplusplus
 }

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -902,6 +902,8 @@ mempool_setup_cb(struct rte_mempool *mp __rte_unused, void *opaque, void *obj,
 
     m->pkt_len  = pkt->pkt_size;
     m->data_len = pkt->pkt_size;
+    m->l2_len   = pkt->ether_hdr_size;
+    m->l3_len   = sizeof(struct rte_ipv4_hdr);
 
     switch (pkt->ethType) {
     case RTE_ETHER_TYPE_IPV4:


### PR DESCRIPTION
GVE GQ requires the L4 offset to be set in the packet descriptor when checksum offloading is enabled for a packet. Retrieving that value requires the L2 and L3 sizes to be set in the mbuf. Furthermore, when computing the checksum, the field is not cleared on the device, which can cause issues with the checksum being incorrect and being rejected by the receiver.

These changes were made to support the use of `pktgen-dpdk` while using the GVE GQ driver.