### PR TITLE
Fixes regarding jumbo frames and offloading.

### DIFF
--- a/app/l2p.c
+++ b/app/l2p.c
@@ -79,8 +79,7 @@ l2p_pktmbuf_create(const char *type, l2p_lport_t *lport, l2p_port_t *port, int n
     pktgen.total_mem_used += sz;
 
     /* create the mbuf pool */
-    mp = rte_pktmbuf_pool_create(name, nb_mbufs, cache_size, DEFAULT_PRIV_SIZE,
-                                 bufSize, sid);
+    mp = rte_pktmbuf_pool_create(name, nb_mbufs, cache_size, DEFAULT_PRIV_SIZE, bufSize, sid);
     if (mp == NULL)
         rte_exit(EXIT_FAILURE,
                  "Cannot create mbuf pool (%s) port %d, queue %d, nb_mbufs %d, NUMA %d: %s\n", name,

--- a/app/l2p.c
+++ b/app/l2p.c
@@ -70,7 +70,7 @@ l2p_pktmbuf_create(const char *type, l2p_lport_t *lport, l2p_port_t *port, int n
 
     snprintf(name, sizeof(name), "%s-L%u/P%u/S%u", type, lport->lid, port->pid, sid);
    
-    const int bufSize =  PG_JUMBO_FRAME_LEN;
+    const int bufSize = PG_JUMBO_FRAME_LEN;
 
     sz = nb_mbufs * bufSize;
     sz = RTE_ALIGN_CEIL(sz + sizeof(struct rte_mempool), 1024);

--- a/app/l2p.c
+++ b/app/l2p.c
@@ -69,8 +69,10 @@ l2p_pktmbuf_create(const char *type, l2p_lport_t *lport, l2p_port_t *port, int n
     sid = pg_eth_dev_socket_id(port->pid);
 
     snprintf(name, sizeof(name), "%s-L%u/P%u/S%u", type, lport->lid, port->pid, sid);
+   
+    const int bufSize =  PG_JUMBO_FRAME_LEN;
 
-    sz = nb_mbufs * RTE_MBUF_DEFAULT_BUF_SIZE;
+    sz = nb_mbufs * bufSize;
     sz = RTE_ALIGN_CEIL(sz + sizeof(struct rte_mempool), 1024);
 
     pktgen.mem_used += sz;
@@ -78,14 +80,14 @@ l2p_pktmbuf_create(const char *type, l2p_lport_t *lport, l2p_port_t *port, int n
 
     /* create the mbuf pool */
     mp = rte_pktmbuf_pool_create(name, nb_mbufs, cache_size, DEFAULT_PRIV_SIZE,
-                                 RTE_MBUF_DEFAULT_BUF_SIZE, sid);
+                                 bufSize, sid);
     if (mp == NULL)
         rte_exit(EXIT_FAILURE,
                  "Cannot create mbuf pool (%s) port %d, queue %d, nb_mbufs %d, NUMA %d: %s\n", name,
                  port->pid, lport->rx_qid, nb_mbufs, sid, rte_strerror(rte_errno));
 
     pktgen_log_info("  Create: '%-*s' - Memory used (MBUFs %'6u x size %'6u) = %'8lu KB @ %p\n", 16,
-                    name, nb_mbufs, RTE_MBUF_DEFAULT_BUF_SIZE, sz / 1024, mp);
+                    name, nb_mbufs, bufSize, sz / 1024, mp);
 
     return mp;
 }

--- a/app/l2p.c
+++ b/app/l2p.c
@@ -69,7 +69,7 @@ l2p_pktmbuf_create(const char *type, l2p_lport_t *lport, l2p_port_t *port, int n
     sid = pg_eth_dev_socket_id(port->pid);
 
     snprintf(name, sizeof(name), "%s-L%u/P%u/S%u", type, lport->lid, port->pid, sid);
-   
+
     const int bufSize = PG_JUMBO_FRAME_LEN;
 
     sz = nb_mbufs * bufSize;

--- a/app/pktgen-cmds.c
+++ b/app/pktgen-cmds.c
@@ -2709,7 +2709,7 @@ single_set_pkt_size(port_info_t *pinfo, uint16_t size)
 
     if ((pktgen.flags & JUMBO_PKTS_FLAG) && size > RTE_ETHER_MAX_JUMBO_FRAME_LEN)
         size = RTE_ETHER_MAX_JUMBO_FRAME_LEN;
-    else if (size > RTE_ETHER_MAX_LEN)
+    else if (!(pktgen.flags & JUMBO_PKTS_FLAG) && size > RTE_ETHER_MAX_LEN)
         size = RTE_ETHER_MAX_LEN;
 
     if ((pkt->ethType == RTE_ETHER_TYPE_IPV6) && (size < MIN_v6_PKT_SIZE))

--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -142,7 +142,7 @@ initialize_port_info(uint16_t pid)
         if (pinfo->dev_info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_MULTI_SEGS)
             conf.txmode.offloads |= RTE_ETH_TX_OFFLOAD_MULTI_SEGS;
     }
-    
+
     if (pinfo->dev_info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_TCP_CKSUM) {
         pktgen_log_info("   Enabling Tx TCP_CKSUM offload");
         conf.txmode.offloads |= RTE_ETH_TX_OFFLOAD_TCP_CKSUM;

--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -39,33 +39,29 @@ enum {
     TX_WTHRESH_1GB = 16, /**< Default value for 1GB ports */
 };
 
+// clang-format off
 static struct rte_eth_conf default_port_conf = {
-    .rxmode =
-        {
-            .mq_mode          = RTE_ETH_MQ_RX_RSS,
-            .max_lro_pkt_size = RTE_ETHER_MAX_LEN,
-            .offloads         = RTE_ETH_RX_OFFLOAD_CHECKSUM,
-            .mtu              = RTE_ETHER_MAX_JUMBO_FRAME_LEN
-          },
-
-    .rx_adv_conf =
-        {
-            .rss_conf =
-                {
-                    .rss_key = NULL,
-                    .rss_hf  = RTE_ETH_RSS_IP | RTE_ETH_RSS_TCP | RTE_ETH_RSS_UDP |
-                              RTE_ETH_RSS_SCTP | RTE_ETH_RSS_L2_PAYLOAD,
-                },
+    .rxmode = {
+        .mq_mode          = RTE_ETH_MQ_RX_RSS,
+        .max_lro_pkt_size = RTE_ETHER_MAX_LEN,
+        .offloads         = RTE_ETH_RX_OFFLOAD_CHECKSUM,
+        .mtu              = RTE_ETHER_MAX_JUMBO_FRAME_LEN
+    },
+    .txmode = {
+        .mq_mode = RTE_ETH_MQ_TX_NONE,
+    },
+    .rx_adv_conf = {
+        .rss_conf = {
+            .rss_key = NULL,
+            .rss_hf  = RTE_ETH_RSS_IP | RTE_ETH_RSS_TCP | RTE_ETH_RSS_UDP |
+                      RTE_ETH_RSS_SCTP | RTE_ETH_RSS_L2_PAYLOAD,
         },
-    .txmode =
-        {
-            .mq_mode = RTE_ETH_MQ_TX_NONE,
-        },
-    .intr_conf =
-        {
-            .lsc = 0,
-        },
+    },
+    .intr_conf = {
+        .lsc = 0,
+    },
 };
+// clang-format on
 
 static void
 dump_device_info(void)
@@ -146,13 +142,11 @@ initialize_port_info(uint16_t pid)
         if (pinfo->dev_info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_MULTI_SEGS)
             conf.txmode.offloads |= RTE_ETH_TX_OFFLOAD_MULTI_SEGS;
     }
-
     
     if (pinfo->dev_info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_TCP_CKSUM) {
         pktgen_log_info("   Enabling Tx TCP_CKSUM offload");
         conf.txmode.offloads |= RTE_ETH_TX_OFFLOAD_TCP_CKSUM;
     }
-  
 
     if (pinfo->dev_info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_UDP_CKSUM) {
         pktgen_log_info("   Enabling Tx UDP_CKSUM offload\r\n");
@@ -163,8 +157,6 @@ initialize_port_info(uint16_t pid)
         pktgen_log_info("   Enabling Tx IPV4_CKSUM offload\r\n");
         conf.txmode.offloads |= RTE_ETH_TX_OFFLOAD_IPV4_CKSUM;
     }
-
-
 
     conf.rx_adv_conf.rss_conf.rss_key = NULL;
     conf.rx_adv_conf.rss_conf.rss_hf &= pinfo->dev_info.flow_type_rss_offloads;

--- a/app/pktgen-stats.c
+++ b/app/pktgen-stats.c
@@ -356,7 +356,7 @@ pktgen_page_stats(void)
         snprintf(buff, sizeof(buff), "%'" PRIu64 "/%'" PRIu64, prev->ierrors, prev->oerrors);
         scrn_printf(row++, col, "%*s", COLUMN_WIDTH_1, buff);
 
-        for (int qid = 0; qid < RTE_ETHDEV_QUEUE_STAT_CNTRS; qid++) {
+        for (int qid = 0; qid < 1; qid++) {
             sizes.broadcast += pinfo->pkt_sizes.broadcast;
             sizes.multicast += pinfo->pkt_sizes.multicast;
             sizes._64 += pinfo->pkt_sizes._64;

--- a/app/pktgen-stats.c
+++ b/app/pktgen-stats.c
@@ -356,7 +356,7 @@ pktgen_page_stats(void)
         snprintf(buff, sizeof(buff), "%'" PRIu64 "/%'" PRIu64, prev->ierrors, prev->oerrors);
         scrn_printf(row++, col, "%*s", COLUMN_WIDTH_1, buff);
 
-        for (int qid = 0; qid < 1; qid++) {
+        for (int qid = 0; qid < RTE_ETHDEV_QUEUE_STAT_CNTRS; qid++) {
             sizes.broadcast += pinfo->pkt_sizes.broadcast;
             sizes.multicast += pinfo->pkt_sizes.multicast;
             sizes._64 += pinfo->pkt_sizes._64;


### PR DESCRIPTION
* Fixed the size check in pktgen-cmds.c when using the `-j` flag.
* Increased the buffer size in l2p.c to have enough space for jumbo frames. This should probably be dependent on the `-j` flag but it works for now.
* Fixed some offloading issues in pktgen-port-config.c since it is assumed that offloading is enabled in e.g. pktgen-ipv4.c and pktgen-tcp.c. These files don't check is offloading is actually enabled or not, they only check the capabilities of the NIC and assumes that it is enabled. (By checking `pinfo->dev_info.tx_offload_capa`.)
* Changed the packet counters in pktgen-stats.c since they were too large, but I'm not sure this fix works in all cases.

