### PR TITLE
fix pktgen startup in automated enviroments

### DIFF
--- a/app/pktgen-main.c
+++ b/app/pktgen-main.c
@@ -383,7 +383,7 @@ main(int argc, char **argv)
     scrn_setw(1);     /* Reset the window size, from possible crash run. */
     scrn_pos(100, 1); /* Move the cursor to the bottom of the screen again */
 
-    print_copyright(PKTGEN_VER_PREFIX, PKTGEN_VER_CREATED_BY);
+    print_copyright(PKTGEN_VERSION, PKTGEN_VER_CREATED_BY);
     fflush(stdout);
 
     /* call before the rte_eal_init() */

--- a/lib/cli/cli_scrn.c
+++ b/lib/cli/cli_scrn.c
@@ -158,6 +158,10 @@ scrn_create(int scrn_type, int theme)
     scrn->type  = scrn_type;
 
     if (scrn_type == SCRN_STDIN_TYPE) {
+        if (tcgetattr(fileno(scrn->fd_in), &scrn->oldterm)) {
+            fprintf(stderr, "%s: tcgetattr failed\n", __func__);
+            exit(-1);
+        }
         memset(&sa, 0, sizeof(struct sigaction));
         sa.sa_handler = handle_winch;
         sigaction(SIGWINCH, &sa, NULL);
@@ -214,8 +218,4 @@ RTE_INIT(scrn_constructor)
     this_scrn = scrn;
 
     scrn_set_io(stdin, stdout);
-    if (tcgetattr(fileno(scrn->fd_in), &scrn->oldterm)) {
-        fprintf(stderr, "%s: tcgetattr failed\n", __func__);
-        exit(-1);
-    }
 }


### PR DESCRIPTION
pktgen did not work in eviroments like pytest anymore. Problem was the call of tcgetattr, which tends to fail in such non-interactive environments.
While being on it I also fixed showing the pktgen version number at startup. 