### PR TITLE
add IPv4 pseudo-header cksum calculation for specific drivers

### DIFF
--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -117,21 +117,21 @@ dump_device_info(void)
 }
 
 /**
-* Determines whether the pseudo-header is required when calculating the checksum.
-* Depends on the original NIC driver (e.g., ixgbe NICs expect the pseudo-header)
-* See Table 1.133: https://doc.dpdk.org/guides/nics/overview.html
-*/
+ * Determines whether the pseudo-header is required when calculating the checksum.
+ * Depends on the original NIC driver (e.g., ixgbe NICs expect the pseudo-header)
+ * See Table 1.133: https://doc.dpdk.org/guides/nics/overview.html
+ */
 bool
 is_cksum_phdr_required(const char *driver_name)
 {
-   size_t num_drivers = sizeof(DRIVERS_REQUIRING_PHDR) / sizeof(DRIVERS_REQUIRING_PHDR[0]);
+    size_t num_drivers = sizeof(DRIVERS_REQUIRING_PHDR) / sizeof(DRIVERS_REQUIRING_PHDR[0]);
 
-   for (size_t i = 0; i < num_drivers; i++) {
-       if (strcmp(driver_name, DRIVERS_REQUIRING_PHDR[i]) == 0)
-           return true;
-   }
+    for (size_t i = 0; i < num_drivers; i++) {
+        if (strcmp(driver_name, DRIVERS_REQUIRING_PHDR[i]) == 0)
+            return true;
+    }
 
-   return false;
+    return false;
 }
 
 static uint32_t
@@ -146,7 +146,6 @@ eth_dev_get_overhead_len(uint32_t max_rx_pktlen, uint16_t max_mtu)
 
     return overhead_len;
 }
-
 
 #define MAX_JUMBO_PKT_LEN 9600
 static port_info_t *

--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -39,6 +39,15 @@ enum {
     TX_WTHRESH_1GB = 16, /**< Default value for 1GB ports */
 };
 
+/**
+ * An array of drivers that require a pseudo-header calculation before the checksum calculation.
+ * The names used are the ones used by DPDK.
+ */
+static const char *DRIVERS_REQUIRING_PHDR[] = {
+    "net_ixgbe",
+    // TODO: Add the others
+};
+
 // clang-format off
 static struct rte_eth_conf default_port_conf = {
     .rxmode = {
@@ -107,6 +116,24 @@ dump_device_info(void)
     printf("\n");
 }
 
+/**
+* Determines whether the pseudo-header is required when calculating the checksum.
+* Depends on the original NIC driver (e.g., ixgbe NICs expect the pseudo-header)
+* See Table 1.133: https://doc.dpdk.org/guides/nics/overview.html
+*/
+bool
+is_cksum_phdr_required(const char *driver_name)
+{
+   size_t num_drivers = sizeof(DRIVERS_REQUIRING_PHDR) / sizeof(DRIVERS_REQUIRING_PHDR[0]);
+
+   for (size_t i = 0; i < num_drivers; i++) {
+       if (strcmp(driver_name, DRIVERS_REQUIRING_PHDR[i]) == 0)
+           return true;
+   }
+
+   return false;
+}
+
 static uint32_t
 eth_dev_get_overhead_len(uint32_t max_rx_pktlen, uint16_t max_mtu)
 {
@@ -119,6 +146,7 @@ eth_dev_get_overhead_len(uint32_t max_rx_pktlen, uint16_t max_mtu)
 
     return overhead_len;
 }
+
 
 #define MAX_JUMBO_PKT_LEN 9600
 static port_info_t *
@@ -198,6 +226,9 @@ initialize_port_info(uint16_t pid)
     }
 
     conf.rxmode.offloads &= pinfo->dev_info.rx_offload_capa;
+
+    /* Determines if pseudo-header is needed, based on the driver type */
+    pinfo->cksum_requires_phdr = is_cksum_phdr_required(pinfo->dev_info.driver_name);
 
     pktgen_log_info("   Allocate packet sequence array");
 

--- a/app/pktgen-port-cfg.h
+++ b/app/pktgen-port-cfg.h
@@ -160,6 +160,11 @@ typedef struct port_info_s {
     char user_pattern[USER_PATTERN_SIZE]; /**< User set pattern values */
     fill_t fill_pattern_type;             /**< Type of pattern to fill with */
 
+    /** Whether the pseudo-header is required when calculating the checksum.
+     *  Depends on the original NIC driver (e.g., ixgbe NICs expect the pseudo-header)
+     *  See Table 1.133: https://doc.dpdk.org/guides/nics/overview.html */
+    bool cksum_requires_phdr;
+
     union {
         uint64_t vxlan; /**< VxLAN 64 bit word */
         struct {

--- a/app/pktgen-tcp.c
+++ b/app/pktgen-tcp.c
@@ -25,7 +25,8 @@
  */
 
 void *
-pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload)
+pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
+                    bool cksum_requires_phdr)
 {
     uint16_t tlen;
 
@@ -53,8 +54,11 @@ pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload)
         tcp->tcp_urp   = 0;
 
         tcp->cksum = 0;
-        if (!cksum_offload)
+        if (!cksum_offload) {
             tcp->cksum = rte_ipv4_udptcp_cksum(ipv4, (const void *)tcp);
+        } else if (cksum_offload && cksum_requires_phdr) {
+            tcp->cksum = rte_ipv4_phdr_cksum(ipv4, 0);
+        }
 
     } else {
         struct rte_ipv6_hdr *ipv6 = (struct rte_ipv6_hdr *)hdr;

--- a/app/pktgen-tcp.c
+++ b/app/pktgen-tcp.c
@@ -54,11 +54,10 @@ pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
         tcp->tcp_urp   = 0;
 
         tcp->cksum = 0;
-        if (!cksum_offload) {
+        if (!cksum_offload)
             tcp->cksum = rte_ipv4_udptcp_cksum(ipv4, (const void *)tcp);
-        } else if (cksum_offload && cksum_requires_phdr) {
+        else if (cksum_offload && cksum_requires_phdr)
             tcp->cksum = rte_ipv4_phdr_cksum(ipv4, 0);
-        }
 
     } else {
         struct rte_ipv6_hdr *ipv6 = (struct rte_ipv6_hdr *)hdr;

--- a/app/pktgen-tcp.h
+++ b/app/pktgen-tcp.h
@@ -28,7 +28,7 @@ extern "C" {
  * SEE ALSO:
  */
 
-void *pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload);
+void *pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload, bool cksum_requires_phdr);
 
 #ifdef __cplusplus
 }

--- a/app/pktgen-tcp.h
+++ b/app/pktgen-tcp.h
@@ -28,7 +28,8 @@ extern "C" {
  * SEE ALSO:
  */
 
-void *pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload, bool cksum_requires_phdr);
+void *pktgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
+                          bool cksum_requires_phdr);
 
 #ifdef __cplusplus
 }

--- a/app/pktgen-udp.c
+++ b/app/pktgen-udp.c
@@ -61,9 +61,8 @@ pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
             udp->dgram_cksum = rte_ipv4_udptcp_cksum(ipv4, (const void *)udp);
             if (udp->dgram_cksum == 0)
                 udp->dgram_cksum = 0xFFFF;
-        } else if (cksum_offload && cksum_requires_phdr) {
+        } else if (cksum_offload && cksum_requires_phdr)
             udp->dgram_cksum = rte_ipv4_phdr_cksum(ipv4, 0);
-        }
 
     } else {
         struct rte_ipv6_hdr *ipv6 = hdr;

--- a/app/pktgen-udp.h
+++ b/app/pktgen-udp.h
@@ -30,7 +30,8 @@ extern "C" {
  * SEE ALSO:
  */
 
-void *pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload);
+void *pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
+                          bool cksum_requires_phdr);
 
 #ifdef __cplusplus
 }

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -521,7 +521,8 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
             bool tcp_cksum_offload = offload_capa & RTE_ETH_TX_OFFLOAD_TCP_CKSUM;
             if (pkt->dport != PG_IPPROTO_L4_GTPU_PORT) {
                 /* Construct the TCP header */
-                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload, pinfo->cksum_requires_phdr);
+                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload,
+                                    pinfo->cksum_requires_phdr);
 
                 /* IPv4 Header constructor */
                 pktgen_ipv4_ctor(pkt, l3_hdr, ipv4_cksum_offload);
@@ -531,7 +532,8 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
                                      0);
 
                 /* Construct the TCP header */
-                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload, pinfo->cksum_requires_phdr);
+                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload,
+                                    pinfo->cksum_requires_phdr);
                 if (sport_entropy != 0) {
                     struct rte_ipv4_hdr *ipv4 = (struct rte_ipv4_hdr *)l3_hdr;
                     struct rte_tcp_hdr *tcp   = (struct rte_tcp_hdr *)&ipv4[1];
@@ -628,7 +630,8 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
         if (pkt->ipProto == PG_IPPROTO_TCP) {
             bool tcp_cksum_offload = offload_capa & RTE_ETH_TX_OFFLOAD_TCP_CKSUM;
             /* Construct the TCP header */
-            pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV6, tcp_cksum_offload, pinfo->cksum_requires_phdr);
+            pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV6, tcp_cksum_offload,
+                                pinfo->cksum_requires_phdr);
             if (sport_entropy != 0) {
                 struct rte_ipv6_hdr *ipv6 = (struct rte_ipv6_hdr *)l3_hdr;
                 struct rte_tcp_hdr *tcp   = (struct rte_tcp_hdr *)&ipv6[1];

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -521,7 +521,7 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
             bool tcp_cksum_offload = offload_capa & RTE_ETH_TX_OFFLOAD_TCP_CKSUM;
             if (pkt->dport != PG_IPPROTO_L4_GTPU_PORT) {
                 /* Construct the TCP header */
-                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload);
+                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload, pinfo->cksum_requires_phdr);
 
                 /* IPv4 Header constructor */
                 pktgen_ipv4_ctor(pkt, l3_hdr, ipv4_cksum_offload);
@@ -531,7 +531,7 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
                                      0);
 
                 /* Construct the TCP header */
-                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload);
+                pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, tcp_cksum_offload, pinfo->cksum_requires_phdr);
                 if (sport_entropy != 0) {
                     struct rte_ipv4_hdr *ipv4 = (struct rte_ipv4_hdr *)l3_hdr;
                     struct rte_tcp_hdr *tcp   = (struct rte_tcp_hdr *)&ipv4[1];
@@ -547,13 +547,15 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
             if (pktgen_tst_port_flags(pinfo, SEND_VXLAN_PACKETS)) {
                 /* Construct the UDP header */
                 pkt->dport = VXLAN_PORT_ID;
-                pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, udp_cksum_offload);
+                pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, udp_cksum_offload,
+                                    pinfo->cksum_requires_phdr);
 
                 /* IPv4 Header constructor */
                 pktgen_ipv4_ctor(pkt, l3_hdr, ipv4_cksum_offload);
             } else if (pkt->dport != PG_IPPROTO_L4_GTPU_PORT) {
                 /* Construct the UDP header */
-                pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, udp_cksum_offload);
+                pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, udp_cksum_offload,
+                                    pinfo->cksum_requires_phdr);
 
                 /* IPv4 Header constructor */
                 pktgen_ipv4_ctor(pkt, l3_hdr, ipv4_cksum_offload);
@@ -563,7 +565,8 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
                                      0);
 
                 /* Construct the UDP header */
-                pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, udp_cksum_offload);
+                pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV4, udp_cksum_offload,
+                                    pinfo->cksum_requires_phdr);
                 if (sport_entropy != 0) {
                     struct rte_ipv4_hdr *ipv4 = (struct rte_ipv4_hdr *)l3_hdr;
                     struct rte_udp_hdr *udp   = (struct rte_udp_hdr *)&ipv4[1];
@@ -625,7 +628,7 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
         if (pkt->ipProto == PG_IPPROTO_TCP) {
             bool tcp_cksum_offload = offload_capa & RTE_ETH_TX_OFFLOAD_TCP_CKSUM;
             /* Construct the TCP header */
-            pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV6, tcp_cksum_offload);
+            pktgen_tcp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV6, tcp_cksum_offload, pinfo->cksum_requires_phdr);
             if (sport_entropy != 0) {
                 struct rte_ipv6_hdr *ipv6 = (struct rte_ipv6_hdr *)l3_hdr;
                 struct rte_tcp_hdr *tcp   = (struct rte_tcp_hdr *)&ipv6[1];
@@ -638,7 +641,8 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
         } else if (pkt->ipProto == PG_IPPROTO_UDP) {
             bool udp_cksum_offload = offload_capa & RTE_ETH_TX_OFFLOAD_UDP_CKSUM;
             /* Construct the UDP header */
-            pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV6, udp_cksum_offload);
+            pktgen_udp_hdr_ctor(pkt, l3_hdr, RTE_ETHER_TYPE_IPV6, udp_cksum_offload,
+                                pinfo->cksum_requires_phdr);
             if (sport_entropy != 0) {
                 struct rte_ipv6_hdr *ipv6 = (struct rte_ipv6_hdr *)l3_hdr;
                 struct rte_udp_hdr *udp   = (struct rte_udp_hdr *)&ipv6[1];


### PR DESCRIPTION
TL;DR:
- fix wrong negation in UDP calculation ([line 60](https://github.com/pktgen/Pktgen-DPDK/compare/main...PedroChaparro123:pedrochaps/fix/cksum-phdr-ixgbe?expand=1#diff-fbab3d624ab6c20247417edb0c0c146ea2cf9952012925feb4c8f48cedc9a122R60))
- add IPv4 pseudo-header cksum calculation for specific drivers

---

Hi! First, I want to thank you for this very nice open source project!

Whilst playing with it, I noticed the checksum calculation was not correct on UDP and TCP packets sent by my ixgbe NIC.
I came to realize this driver (and others) does not perform a completely independent checksum (as per this [table](https://doc.dpdk.org/guides/nics/overview.html)), instead expecting a software pseudo-header (phdr) checksum computation to be inserted in the checksum field of the packet (some resources on this phdr: [udp](https://www.omnisecu.com/tcpip/udp-pseudo-header.php), [tcp](https://www.baeldung.com/cs/pseudo-header-tcp)) before passing it to the NIC.

So, I added some code that performs extra logic to compute the phdr cksum and insert it, when the NIC is one of these "special NICs". This NIC classification is determined, to not downgrade performance, before the main packet preparation and sending loop starts. Then, on the main loop, a simple boolean comparison was added, with a new field in the packet structure.

This patch was tested on my machine and it works!
I am not sure about the other drivers and I do not have NICs supporting them, so I cannot test. Thus, I left a "TODO".

I also noticed I think a [typo on the UDP checksum part](https://github.com/pktgen/Pktgen-DPDK/compare/main...PedroChaparro123:pedrochaps/fix/cksum-phdr-ixgbe?expand=1#diff-fbab3d624ab6c20247417edb0c0c146ea2cf9952012925feb4c8f48cedc9a122R60), where the logic was inverted: software checksum was being computed when it was supposed to be offloaded, and packets were being sent with checksum 0x0000 when offloading was expected to happen.

Main concerns:
- [ ] **IPv4 only**: This patch is only for IPv4. I have not played with IPv6 packets yet, but I'm happy to also contribute if the changes make sense.
- [ ] **rnd still broken**: I inserted all this logic alongside the rest of the header computation, which happens before the bit randomization (i.e., `rnd` page; `pktgen_rnd_bits_apply()` function) takes place. This means that if a phdr field is randomized (e.g., target port), the cksum will still be incorrect. I didn't find a way to easily integrate this.

Let me know what you think!




