### PR TITLE
add `enable` command for src IP randomization (and maybe port)

### DIFF
--- a/app/cli-functions.c
+++ b/app/cli-functions.c
@@ -66,14 +66,17 @@ static const char *title_help[] = {
 
 static const char *status_help[] = {
     "",
-    "       Flags: P----------------- - Promiscuous mode enabled",
-    "               E                 - ICMP Echo enabled",
-    "                B                - Bonding enabled LACP 802.3ad",
-    "                 I               - Process packets on input enabled",
-    "                  *              - Using TAP interface for this port can be [-rt*]",
-    "                   C             - Capture received packets",
-    "                    ------       - Modes Single, pcap, sequence, latency, random, Rate",
-    "                          ------ - Modes VLAN, VxLAN, MPLS, QnQ, GRE IPv4, GRE ETH",
+    "       Flags: P------------------------ - Promiscuous mode enabled",
+    "               E                        - ICMP Echo enabled",
+    "                B                       - Bonding enabled LACP 802.3ad",
+    "                 I                      - Process packets on input enabled",
+    "                  L                     - Sends latency packets",
+    "                   i                    - Randomizing the source IP address",
+    "                    R                   - Perform bit randomization (`rnd` page)",
+    "                     C                  - Capture received packets",
+    "                      <.......>          - Modes: Single, pcap, sequence, latency, "
+    "Rate",
+    "                               <......> - Modes: VLAN, VxLAN, MPLS, QnQ, GRE IPv4, GRE ETH",
     "Notes: <state>       - Use enable|disable or on|off to set the state.",
     "       <portlist>    - a list of ports (no spaces) as 2,4,6-9,12 or 3-5,8 or 5 or the word "
     "'all'",
@@ -1001,24 +1004,25 @@ theme_cmd(int argc, char **argv)
     return 0;
 }
 
-#define ed_type         \
-    "process|" /*  0 */ \
-    "mpls|"    /*  1 */ \
-    "qinq|"    /*  2 */ \
-    "gre|"     /*  3 */ \
-    "gre_eth|" /*  4 */ \
-    "vlan|"    /*  5 */ \
-    "random|"  /*  6 */ \
-    "latency|" /*  7 */ \
-    "pcap|"    /*  8 */ \
-    "blink|"   /*  9 */ \
-    "icmp|"    /* 10 */ \
-    "range|"   /* 11 */ \
-    "capture|" /* 12 */ \
-    "bonding|" /* 13 */ \
-    "vxlan|"   /* 14 */ \
-    "rate|"    /* 15 */ \
-    "lat"      /* 16 */
+#define ed_type          \
+    "process|"  /*  0 */ \
+    "mpls|"     /*  1 */ \
+    "qinq|"     /*  2 */ \
+    "gre|"      /*  3 */ \
+    "gre_eth|"  /*  4 */ \
+    "vlan|"     /*  5 */ \
+    "random|"   /*  6 */ \
+    "latency|"  /*  7 */ \
+    "pcap|"     /*  8 */ \
+    "blink|"    /*  9 */ \
+    "icmp|"     /* 10 */ \
+    "range|"    /* 11 */ \
+    "capture|"  /* 12 */ \
+    "bonding|"  /* 13 */ \
+    "vxlan|"    /* 14 */ \
+    "rate|"     /* 15 */ \
+    "rnd_s_ip|" /* 16 */ \
+    "lat"       /* 17 */
 
 // clang-format off
 static struct cli_map enable_map[] = {
@@ -1041,7 +1045,9 @@ static const char *enable_help[] = {
     "enable|disable <portlist> gre      - Enable/disable GRE support",
     "enable|disable <portlist> gre_eth  - Enable/disable GRE with Ethernet frame payload",
     "enable|disable <portlist> vlan     - Enable/disable VLAN tagging",
-    "enable|disable <portlist> random   - Enable/disable Random packet support",
+    "enable|disable <portlist> rnd_s_ip - Enable/disable randomizing the source IP address on "
+    "every packet",
+    "enable|disable <portlist> random   - Enable/disable Random packet support through the `rnd` page",
     "enable|disable <portlist> latency  - Enable/disable latency testing",
     "enable|disable <portlist> pcap     - Enable or Disable sending pcap packets on a portlist",
     "enable|disable <portlist> blink    - Blink LED on port(s)",
@@ -1105,7 +1111,7 @@ en_dis_cmd(int argc, char **argv)
             foreach_port(portlist, enable_random(pinfo, state));
             break;
         case 7:
-        case 16: /* lat or latency type */
+        case 17: /* lat or latency type */
             foreach_port(portlist, enable_latency(pinfo, state));
             break;
         case 8:
@@ -1135,6 +1141,9 @@ en_dis_cmd(int argc, char **argv)
             break;
         case 14:
             foreach_port(portlist, enable_vxlan(pinfo, state));
+            break;
+        case 16:
+            foreach_port(portlist, enable_rnd_s_ip(pinfo, state));
             break;
         default:
             return cli_cmd_error("Enable/Disable invalid command", "Enable", argc, argv);

--- a/app/lpktgenlib.c
+++ b/app/lpktgenlib.c
@@ -3360,7 +3360,7 @@ port_info(lua_State *L, port_info_t *pinfo)
     setf_string(L, "proto_type",
                 (pkt->ipProto == PG_IPPROTO_TCP)                               ? "TCP"
                 : (pkt->ipProto == PG_IPPROTO_ICMP)                            ? "ICMP"
-                : (rte_atomic32_read(&pinfo->port_flags) & SEND_VXLAN_PACKETS) ? "VXLAN"
+                : (rte_atomic64_read(&pinfo->port_flags) & SEND_VXLAN_PACKETS) ? "VXLAN"
                                                                                : "UDP");
     setf_integer(L, "vlanid", pkt->vlanid);
 

--- a/app/meson.build
+++ b/app/meson.build
@@ -26,6 +26,7 @@ sources = files(
 	'pktgen-udp.c',
 	'pktgen-vlan.c',
 	'pktgen.c',
+	'xorshift64star.c',
 )
 
 if get_option('enable_lua')

--- a/app/pktgen-capture.c
+++ b/app/pktgen-capture.c
@@ -87,7 +87,7 @@ pktgen_set_capture(port_info_t *pinfo, uint32_t onOff)
 
     if (onOff == ENABLE_STATE) {
         /* Enabling an already enabled port is a no-op */
-        if (rte_atomic32_read(&pinfo->port_flags) & CAPTURE_PKTS)
+        if (rte_atomic64_read(&pinfo->port_flags) & CAPTURE_PKTS)
             return;
 
         /* Find an lcore that can capture packets for the requested port */
@@ -134,7 +134,7 @@ pktgen_set_capture(port_info_t *pinfo, uint32_t onOff)
                                     * frame overhead: 84 bytes per packet */
         );
     } else {
-        if (!(rte_atomic32_read(&pinfo->port_flags) & CAPTURE_PKTS))
+        if (!(rte_atomic64_read(&pinfo->port_flags) & CAPTURE_PKTS))
             return;
 
         int sid;

--- a/app/pktgen-cmds.h
+++ b/app/pktgen-cmds.h
@@ -120,6 +120,7 @@
     void enable_gre(port_info_t * pinfo, uint32_t state);
     void enable_gre_eth(port_info_t * pinfo, uint32_t state);
     void enable_icmp_echo(port_info_t * pinfo, uint32_t state);
+    void enable_rnd_s_ip(port_info_t * pinfo, uint32_t state);
     void enable_random(port_info_t * pinfo, uint32_t state);
     void enable_latency(port_info_t * pinfo, uint32_t state);
     void enable_mac_from_arp(uint32_t state);

--- a/app/pktgen-ipv4.c
+++ b/app/pktgen-ipv4.c
@@ -119,7 +119,7 @@ pktgen_process_ping4(struct rte_mbuf *m, uint32_t pid, uint32_t qid, uint32_t vl
         ip = (struct rte_ipv4_hdr *)((char *)ip + sizeof(struct rte_vlan_hdr));
 
     /* Look for a ICMP echo requests, but only if enabled. */
-    if ((rte_atomic32_read(&pinfo->port_flags) & ICMP_ECHO_ENABLE_FLAG) &&
+    if ((rte_atomic64_read(&pinfo->port_flags) & ICMP_ECHO_ENABLE_FLAG) &&
         (ip->next_proto_id == PG_IPPROTO_ICMP)) {
         struct rte_icmp_hdr *icmp =
             (struct rte_icmp_hdr *)((uintptr_t)ip + sizeof(struct rte_ipv4_hdr));

--- a/app/pktgen-port-cfg.h
+++ b/app/pktgen-port-cfg.h
@@ -39,45 +39,46 @@ extern "C" {
 // clang-format off
 enum { /* Per port flag bits */
        /* Supported packet modes non-exclusive */
-       SEND_ARP_REQUEST         = (1 << 0), /**< Send a ARP request */
-       SEND_GRATUITOUS_ARP      = (1 << 1), /**< Send a Gratuitous ARP */
-       ICMP_ECHO_ENABLE_FLAG    = (1 << 2), /**< Enable ICMP Echo support */
-       BONDING_TX_PACKETS       = (1 << 3), /**< Bonding driver send zero pkts */
+       SEND_ARP_REQUEST         = (1ULL << 0), /**< Send a ARP request */
+       SEND_GRATUITOUS_ARP      = (1ULL << 1), /**< Send a Gratuitous ARP */
+       ICMP_ECHO_ENABLE_FLAG    = (1ULL << 2), /**< Enable ICMP Echo support */
+       BONDING_TX_PACKETS       = (1ULL << 3), /**< Bonding driver send zero pkts */
 
        /* Receive packet modes */
-       PROCESS_INPUT_PKTS       = (1 << 4), /**< Process input packets */
-       CAPTURE_PKTS             = (1 << 5), /**< Capture received packets */
-       SAMPLING_LATENCIES       = (1 << 6), /**< Sampling latency measurements */
+       PROCESS_INPUT_PKTS       = (1ULL << 4), /**< Process input packets */
+       CAPTURE_PKTS             = (1ULL << 5), /**< Capture received packets */
+       SAMPLING_LATENCIES       = (1ULL << 6), /**< Sampling latency measurements */
 
-       SEND_PING4_REQUEST       = (1 << 8), /**< Send a IPv4 Ping request */
-       SEND_PING6_REQUEST       = (1 << 9), /**< Send a IPv6 Ping request */
+       SEND_PING4_REQUEST       = (1ULL << 8), /**< Send a IPv4 Ping request */
+       SEND_PING6_REQUEST       = (1ULL << 9), /**< Send a IPv6 Ping request */
 
        /* Exclusive Packet sending modes */
-       SEND_SINGLE_PKTS         = (1 << 12), /**< Send single packets */
-       SEND_PCAP_PKTS           = (1 << 13), /**< Send a pcap file of packets */
-       SEND_RANGE_PKTS          = (1 << 14), /**< Send range of packets */
-       SEND_SEQ_PKTS            = (1 << 15), /**< Send sequence of packets */
+       SEND_SINGLE_PKTS         = (1ULL << 12), /**< Send single packets */
+       SEND_PCAP_PKTS           = (1ULL << 13), /**< Send a pcap file of packets */
+       SEND_RANGE_PKTS          = (1ULL << 14), /**< Send range of packets */
+       SEND_SEQ_PKTS            = (1ULL << 15), /**< Send sequence of packets */
 
        /* Exclusive Packet type modes */
-       SEND_RANDOM_PKTS         = (1 << 16), /**< Send random bitfields in packets */
-       SEND_VLAN_ID             = (1 << 17), /**< Send packets with VLAN ID */
-       SEND_MPLS_LABEL          = (1 << 18), /**< Send MPLS label */
-       SEND_Q_IN_Q_IDS          = (1 << 19), /**< Send packets with Q-in-Q */
+       SEND_RANDOM_PKTS         = (1ULL << 16), /**< Send random bitfields in packets */
+       SEND_VLAN_ID             = (1ULL << 17), /**< Send packets with VLAN ID */
+       SEND_MPLS_LABEL          = (1ULL << 18), /**< Send MPLS label */
+       SEND_Q_IN_Q_IDS          = (1ULL << 19), /**< Send packets with Q-in-Q */
        
-       SEND_GRE_IPv4_HEADER     = (1 << 20), /**< Encapsulate IPv4 in GRE */
-       SEND_GRE_ETHER_HEADER    = (1 << 21), /**< Encapsulate Ethernet frame in GRE */
-       SEND_VXLAN_PACKETS       = (1 << 22), /**< Send VxLAN Packets */
-       SEND_LATENCY_PKTS        = (1 << 23), /**< Send latency packets in any mode */
+       SEND_GRE_IPv4_HEADER     = (1ULL << 20), /**< Encapsulate IPv4 in GRE */
+       SEND_GRE_ETHER_HEADER    = (1ULL << 21), /**< Encapsulate Ethernet frame in GRE */
+       SEND_VXLAN_PACKETS       = (1ULL << 22), /**< Send VxLAN Packets */
+       SEND_LATENCY_PKTS        = (1ULL << 23), /**< Send latency packets in any mode */
 
        /* Sending flags */
-       SETUP_TRANSMIT_PKTS      = (1 << 28), /**< Need to setup transmit packets */
-       STOP_RECEIVING_PACKETS   = (1 << 29), /**< Stop receiving packet */
-       SENDING_PACKETS          = (1 << 30), /**< sending packets on this port */
-       SEND_FOREVER             = (1 << 31), /**< Send packets forever */
+       SETUP_TRANSMIT_PKTS      = (1ULL << 28), /**< Need to setup transmit packets */
+       STOP_RECEIVING_PACKETS   = (1ULL << 29), /**< Stop receiving packet */
+       SENDING_PACKETS          = (1ULL << 30), /**< sending packets on this port */
+       SEND_FOREVER             = (1ULL << 31), /**< Send packets forever */
 
        SEND_ARP_PING_REQUESTS   =
            (SEND_ARP_REQUEST | SEND_GRATUITOUS_ARP | SEND_PING4_REQUEST | SEND_PING6_REQUEST)
 };
+#define RANDOMIZE_SRC_IP (1ULL << 32) /**< Set the source IP address as random */
 // clang-format on
 
 #define EXCLUSIVE_MODES (SEND_SINGLE_PKTS | SEND_PCAP_PKTS | SEND_RANGE_PKTS | SEND_SEQ_PKTS)
@@ -128,7 +129,7 @@ typedef struct {
 } latency_t;
 
 typedef struct port_info_s {
-    rte_atomic32_t port_flags;        /**< Special send flags for ARP and other */
+    rte_atomic64_t port_flags;        /**< Special send flags for ARP and other */
     rte_atomic64_t transmit_count;    /**< Packets to transmit loaded into current_tx_count */
     rte_atomic64_t current_tx_count;  /**< Current number of packets to send */
     volatile uint64_t tx_cycles;      /**< Number cycles between TX bursts */

--- a/app/pktgen-random.c
+++ b/app/pktgen-random.c
@@ -19,7 +19,6 @@
 #include "pktgen-display.h"
 #include "pktgen-log.h"
 
-#include "xorshift64star.h" /* PRNG function */
 
 /* Allow PRNG function to be changed at runtime for testing*/
 #ifdef TESTING
@@ -28,24 +27,6 @@ static rnd_func_t _rnd_func = NULL;
 
 /* Forward declaration */
 static void pktgen_init_default_rnd(void);
-
-/**
- *
- * pktgen_default_rnd_func - Default function used to generate random values
- *
- * DESCRIPTION
- * Default function to use for generating random values. This function is used
- * when no external random function is set using pktgen_set_rnd_func();
- *
- * RETURNS: 32-bit random value.
- *
- * SEE ALSO:
- */
-static __inline__ uint32_t
-pktgen_default_rnd_func(void)
-{
-    return (uint32_t)xorshift64star();
-}
 
 /**
  *

--- a/app/pktgen-random.c
+++ b/app/pktgen-random.c
@@ -19,7 +19,6 @@
 #include "pktgen-display.h"
 #include "pktgen-log.h"
 
-
 /* Allow PRNG function to be changed at runtime for testing*/
 #ifdef TESTING
 static rnd_func_t _rnd_func = NULL;

--- a/app/pktgen-random.h
+++ b/app/pktgen-random.h
@@ -14,6 +14,8 @@
 
 #include "pktgen-seq.h"
 
+#include "xorshift64star.h" /* PRNG function */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,6 +56,24 @@ void pktgen_rnd_bits_apply(struct port_info_s *info, struct rte_mbuf **pkt, size
 
 /* Display page with random bitfield settings */
 void pktgen_page_random_bitfields(uint32_t print_labels, uint16_t pid, struct rnd_bits_s *rnd_bits);
+
+/**
+ *
+ * pktgen_default_rnd_func - Default function used to generate random values
+ *
+ * DESCRIPTION
+ * Default function to use for generating random values. This function is used
+ * when no external random function is set using pktgen_set_rnd_func();
+ *
+ * RETURNS: 32-bit random value.
+ *
+ * SEE ALSO:
+ */
+static __inline__ uint32_t
+pktgen_default_rnd_func(void)
+{
+    return (uint32_t)xorshift64star();
+}
 
 #ifdef TESTING
 /* Change PRNG function at runtime */

--- a/app/pktgen-stats.c
+++ b/app/pktgen-stats.c
@@ -145,7 +145,7 @@ pktgen_print_static_data(void)
                                                          : "Other",
                  (pkt->ipProto == PG_IPPROTO_TCP)                               ? "TCP"
                  : (pkt->ipProto == PG_IPPROTO_ICMP)                            ? "ICMP"
-                 : (rte_atomic32_read(&pinfo->port_flags) & SEND_VXLAN_PACKETS) ? "VXLAN"
+                 : (rte_atomic64_read(&pinfo->port_flags) & SEND_VXLAN_PACKETS) ? "VXLAN"
                                                                                 : "UDP",
                  pkt->vlanid, pkt->tcp_flags);
         scrn_printf(row++, col, "%*s", COLUMN_WIDTH_1, buff);

--- a/app/pktgen-udp.c
+++ b/app/pktgen-udp.c
@@ -34,6 +34,7 @@ pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
         struct rte_ipv4_hdr *ipv4 = hdr;
         struct rte_udp_hdr *udp   = (struct rte_udp_hdr *)&ipv4[1];
 
+        
         /* Create the UDP header */
         ipv4->src_addr = htonl(pkt->ip_src_addr.addr.ipv4.s_addr);
         ipv4->dst_addr = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);

--- a/app/pktgen-udp.c
+++ b/app/pktgen-udp.c
@@ -34,7 +34,6 @@ pktgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type, bool cksum_offload,
         struct rte_ipv4_hdr *ipv4 = hdr;
         struct rte_udp_hdr *udp   = (struct rte_udp_hdr *)&ipv4[1];
 
-        
         /* Create the UDP header */
         ipv4->src_addr = htonl(pkt->ip_src_addr.addr.ipv4.s_addr);
         ipv4->dst_addr = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);

--- a/app/pktgen.c
+++ b/app/pktgen.c
@@ -506,6 +506,18 @@ pktgen_packet_ctor(port_info_t *pinfo, int32_t seq_idx, int32_t type)
         if (lat->latency_entropy)
             sport_entropy = (uint16_t)(pkt->sport + (tstamp->index % lat->latency_entropy));
     }
+
+    /*
+     * Randomizes the source IP address if in the single packet setting and not processing input
+     * packets.
+     * For details, see https://github.com/pktgen/Pktgen-DPDK/pull/342
+     */
+
+    if (pktgen_tst_port_flags(pinfo, RANDOMIZE_SRC_IP) &&
+        pktgen_tst_port_flags(pinfo, SEND_SINGLE_PKTS) &&
+        !pktgen_tst_port_flags(pinfo, PROCESS_INPUT_PKTS))
+        pkt->ip_src_addr.addr.ipv4.s_addr = pktgen_default_rnd_func();
+
     /* Add GRE header and adjust rte_ether_hdr pointer if requested */
     if (pktgen_tst_port_flags(pinfo, SEND_GRE_IPv4_HEADER))
         l3_hdr = pktgen_gre_hdr_ctor(pinfo, pkt, (greIp_t *)l3_hdr);

--- a/app/pktgen.h
+++ b/app/pktgen.h
@@ -385,30 +385,30 @@ typedef struct {
 #define TSTAMP_MAGIC 0xf00dcafe
 
 static __inline__ void
-pktgen_set_port_flags(port_info_t *pinfo, uint32_t flags)
+pktgen_set_port_flags(port_info_t *pinfo, uint64_t flags)
 {
-    uint32_t val;
+    uint64_t val;
 
     do {
-        val = rte_atomic32_read(&pinfo->port_flags);
-    } while (!rte_atomic32_cmpset((volatile uint32_t *)&pinfo->port_flags.cnt, val, (val | flags)));
+        val = rte_atomic64_read(&pinfo->port_flags);
+    } while (!rte_atomic64_cmpset((volatile uint64_t *)&pinfo->port_flags.cnt, val, (val | flags)));
 }
 
 static __inline__ void
-pktgen_clr_port_flags(port_info_t *pinfo, uint32_t flags)
+pktgen_clr_port_flags(port_info_t *pinfo, uint64_t flags)
 {
-    uint32_t val;
+    uint64_t val;
 
     do {
-        val = rte_atomic32_read(&pinfo->port_flags);
+        val = rte_atomic64_read(&pinfo->port_flags);
     } while (
-        !rte_atomic32_cmpset((volatile uint32_t *)&pinfo->port_flags.cnt, val, (val & ~flags)));
+        !rte_atomic64_cmpset((volatile uint64_t *)&pinfo->port_flags.cnt, val, (val & ~flags)));
 }
 
 static __inline__ int
-pktgen_tst_port_flags(port_info_t *pinfo, uint32_t flags)
+pktgen_tst_port_flags(port_info_t *pinfo, uint64_t flags)
 {
-    return ((rte_atomic32_read(&pinfo->port_flags) & flags) ? 1 : 0);
+    return ((rte_atomic64_read(&pinfo->port_flags) & flags) ? 1 : 0);
 }
 
 /* onOff values */

--- a/app/xorshift64star.c
+++ b/app/xorshift64star.c
@@ -1,0 +1,5 @@
+#include "xorshift64star.h"
+
+// The state of the "randomization engine".
+// Defined here so that it can be shared between files.
+uint64_t xor_state[1] = {1};

--- a/app/xorshift64star.h
+++ b/app/xorshift64star.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-static uint64_t xor_state[1];
+extern uint64_t xor_state[1];
 
 static inline uint64_t
 xorshift64star(void)


### PR DESCRIPTION
(still a draft)

## Intro

This PR adds an `enable` command to make the source IP address randomizable. 

See Issue #341 for more details and discussion.

## Actions for the PR to be completed

#### Initial Steps

Src IP randomization
- [x] add enable help page entry
- [x] add Flags help page entry
- [x] add new mode on the 'Port:Flags' line of the main page
- [x] ensure no interference with packets that are responses to other packets (e.g., if responding to an ARP request, the source IP should not be randomized)
- [x] ensure randomization only happens on "Single Packet" mode (e.g., don't interfere with `range`, `rnd` mode)
- [x] check code formatting and style

Src port randomization
- [ ] _same of source IP but for the source port_

#### Improve Randomization

- [ ] Research and maybe improve randomization function

#### Geo-location setting

- [ ] Add an option to provide a country/list of countries/list of IPs/subnet to constrain the IPs that can be generated