### PR TITLE
latency values for 90th 95th and 99th percentiles

### DIFF
--- a/app/pktgen-port-cfg.h
+++ b/app/pktgen-port-cfg.h
@@ -100,6 +100,13 @@ typedef enum {
 
 typedef void (*tx_func_t)(struct port_info_s *info, uint16_t qid);
 
+#define RING_SIZE 1000
+typedef struct {
+    uint64_t data[RING_SIZE];
+    int head;  /**< index of next write position */
+    int count; /**< number of elements */
+} latency_ring_t;
+
 typedef struct {
     uint64_t data[MAX_LATENCY_ENTRIES]; /** Record for latencies */
     uint32_t idx;                       /**< Index to the latencies array */
@@ -127,6 +134,7 @@ typedef struct {
     uint64_t max_cycles;              /**< maximum cycles per latency packet */
     uint32_t next_index;              /**< Next index to use for sending latency packets */
     uint32_t expect_index;            /**< Expected index for received latency packets */
+    latency_ring_t tail_latencies;    /**< ring buffer for tail latencies */
     MARKER end_stats;
 } latency_t;
 


### PR DESCRIPTION
Introduced real-time calculation of the 90th, 95th and 99th percentiles for latency values using a ring buffer of 1k elements

For my research project, the existing latency metrics (min, avg, and max) were not sufficient, as I needed to observe tail latencies to better understand packet delay distribution under load.

To address this, I extended Pktgen to compute real-time percentile estimates (P90, P95, P99) using a ring buffer of 1k elements.

I previously tried with the P-square algorithm but were having inconsistent results.

For my tests storing 1k latency packets was enough but the size of the ring buffer could be changed through `#define RING_SIZE 1000` in `app/pktgen-port-cfg.h`

Changes:

- Extended `latency_t` struct in `app/pktgen-port-cfg.h` to include the ring buffer of the last 1k latencies
- Added `latency_ring_insert` function in `app/pktgen.c` to add latetencies to the ring buffer
- Modified `app/pktgen-latency.c` to sort and display percentile results

<img width="428" height="603" alt="tail-lat" src="https://github.com/user-attachments/assets/52b86d6b-b070-41e1-a624-3054e1a783bc" />
