### PR TITLE
port-cfg: fix TX queue setup using wrong descriptor count

### DIFF
--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -468,7 +468,7 @@ _tx_queues(port_info_t *pinfo)
 
         pktgen_log_info("     TX queue %d enabled offloads: 0x%0lx", q, txq_conf.offloads);
 
-        ret = rte_eth_tx_queue_setup(pid, q, pktgen.nb_rxd, pinfo->sid, &txq_conf);
+        ret = rte_eth_tx_queue_setup(pid, q, pktgen.nb_txd, pinfo->sid, &txq_conf);
         if (ret < 0)
             pktgen_log_panic("rte_eth_tx_queue_setup: err=%d, port=%d, %s", ret, pid,
                              rte_strerror(-ret));


### PR DESCRIPTION
## Description

Fixed a bug where `rte_eth_tx_queue_setup()` was incorrectly using `pktgen.nb_rxd` (RX descriptor count) instead of `pktgen.nb_txd` (TX descriptor count).

## Problem

In `app/pktgen-port-cfg.c` line 471, TX queue setup was using the RX descriptor count:
```c
ret = rte_eth_tx_queue_setup(pid, q, pktgen.nb_rxd, pinfo->sid, &txq_conf);
                                       ^^^^^^^^^^ Wrong!
```

This caused TX queues to be configured with RX ring size, potentially leading to:
- Suboptimal TX performance
- Configuration mismatches between intended and actual TX queue sizes
- Unexpected behavior when RX and TX descriptor counts differ

## Solution

Changed to use the correct `pktgen.nb_txd` parameter:
```c
ret = rte_eth_tx_queue_setup(pid, q, pktgen.nb_txd, pinfo->sid, &txq_conf);
                                       ^^^^^^^^^^ Correct
```

## Testing

Verified that TX queues now respect the `DEFAULT_TX_DESC` configuration parameter independently from `DEFAULT_RX_DESC`.

## Impact

This is a bug fix with no API changes. Users who relied on TX descriptor count configuration will now see the intended behavior.