### PR TITLE
Fix compilation with lua 5.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: '^(builddir/.*|specs/.*|.github/.*|.githooks/.*)'
 repos:
   # General code quality hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -26,7 +26,7 @@ repos:
 
   # C/C++ specific formatting and linting
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.5
+    rev: v22.1.0
     hooks:
       - id: clang-format
         args: ['-i']
@@ -48,7 +48,7 @@ repos:
 
   # Documentation and markdown
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.41.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
         args: ['--fix', '--disable', 'MD013', 'MD033']

--- a/app/pktgen-latency.h
+++ b/app/pktgen-latency.h
@@ -26,10 +26,10 @@ extern "C" {
 
 #define DEFAULT_JITTER_THRESHOLD (50)    /**< Default jitter threshold in microseconds */
 #define DEFAULT_LATENCY_RATE     (10000) /**< Default probe injection rate in microseconds */
-#define MAX_LATENCY_RATE         (1000000) /**< Maximum allowed probe injection rate in microseconds */
-#define DEFAULT_LATENCY_ENTROPY  (0) /**< Default entropy seed for source port randomisation */
-#define LATENCY_PKT_SIZE         RTE_ETHER_MIN_LEN /**< Latency probe packet size (64 B + 4 B FCS) */
-#define LATENCY_DPORT            1028 /**< Destination UDP port used for latency probes */
+#define MAX_LATENCY_RATE (1000000)  /**< Maximum allowed probe injection rate in microseconds */
+#define DEFAULT_LATENCY_ENTROPY (0) /**< Default entropy seed for source port randomisation */
+#define LATENCY_PKT_SIZE        RTE_ETHER_MIN_LEN /**< Latency probe packet size (64 B + 4 B FCS) */
+#define LATENCY_DPORT           1028 /**< Destination UDP port used for latency probes */
 
 /**
  * Render the latency statistics display page to the console.

--- a/app/pktgen-port-cfg.c
+++ b/app/pktgen-port-cfg.c
@@ -59,7 +59,7 @@ static struct rte_eth_conf default_port_conf = {
                 {
                     .rss_key = NULL,
                     .rss_hf  = RTE_ETH_RSS_IP | RTE_ETH_RSS_TCP | RTE_ETH_RSS_UDP |
-                              RTE_ETH_RSS_SCTP | RTE_ETH_RSS_L2_PAYLOAD,
+                               RTE_ETH_RSS_SCTP | RTE_ETH_RSS_L2_PAYLOAD,
                 },
         },
     .intr_conf =

--- a/examples/pktperf/port.c
+++ b/examples/pktperf/port.c
@@ -49,7 +49,7 @@ static struct rte_eth_conf port_conf = {
                 {
                     .rss_key = NULL,
                     .rss_hf  = RTE_ETH_RSS_IP | RTE_ETH_RSS_TCP | RTE_ETH_RSS_UDP |
-                              RTE_ETH_RSS_SCTP | RTE_ETH_RSS_L2_PAYLOAD,
+                               RTE_ETH_RSS_SCTP | RTE_ETH_RSS_L2_PAYLOAD,
                 },
         },
     .intr_conf =

--- a/examples/pktperf/utils.c
+++ b/examples/pktperf/utils.c
@@ -147,7 +147,7 @@ packet_constructor(l2p_lport_t *lport, uint8_t *pkt, uint16_t proto)
         udp->dst_port = rte_cpu_to_be_16(get_rand(0xFFFE) + 1);
 
         len              = (uint16_t)(info->pkt_size - sizeof(struct rte_ether_hdr) -
-                         sizeof(struct rte_ipv4_hdr) - RTE_ETHER_CRC_LEN);
+                                      sizeof(struct rte_ipv4_hdr) - RTE_ETHER_CRC_LEN);
         udp->dgram_len   = rte_cpu_to_be_16(len);
         udp->dgram_cksum = 0;
         udp->dgram_cksum = rte_ipv4_udptcp_cksum(ipv4, (const void *)udp);

--- a/lib/lua/lua_config.c
+++ b/lib/lua/lua_config.c
@@ -179,8 +179,7 @@ lua_create_instance(void)
     rte_mcfg_tailq_read_unlock();
 
     /* Make sure we display the copyright string for Lua. */
-    lua_writestring(LUA_COPYRIGHT, strlen(LUA_COPYRIGHT));
-    lua_writeline();
+    printf("%s\n", LUA_COPYRIGHT);
 
     return ld;
 }

--- a/lib/lua/lua_dpdk.h
+++ b/lib/lua/lua_dpdk.h
@@ -81,133 +81,140 @@ extern "C" {
         }                                                                              \
     } while ((0))
 
-    struct pkt_data {
-        /* Packet type and information */
-        struct rte_ether_addr eth_dst_addr; /**< Destination Ethernet address */
-        struct rte_ether_addr eth_src_addr; /**< Source Ethernet address */
+struct pkt_data {
+    /* Packet type and information */
+    struct rte_ether_addr eth_dst_addr; /**< Destination Ethernet address */
+    struct rte_ether_addr eth_src_addr; /**< Source Ethernet address */
 
-        uint32_t ip_src_addr; /**< Source IPv4 address also used for IPv6 */
-        uint32_t ip_dst_addr; /**< Destination IPv4 address */
-        uint32_t ip_mask;     /**< IPv4 Netmask value */
+    uint32_t ip_src_addr; /**< Source IPv4 address also used for IPv6 */
+    uint32_t ip_dst_addr; /**< Destination IPv4 address */
+    uint32_t ip_mask;     /**< IPv4 Netmask value */
 
-        uint16_t sport;          /**< Source port value */
-        uint16_t dport;          /**< Destination port value */
-        uint16_t ethType;        /**< IPv4 or IPv6 */
-        uint16_t ipProto;        /**< TCP or UDP or ICMP */
-        uint16_t vlanid;         /**< VLAN ID value if used */
-        uint16_t ether_hdr_size; /**< Size of Ethernet header in packet for VLAN ID */
+    uint16_t sport;          /**< Source port value */
+    uint16_t dport;          /**< Destination port value */
+    uint16_t ethType;        /**< IPv4 or IPv6 */
+    uint16_t ipProto;        /**< TCP or UDP or ICMP */
+    uint16_t vlanid;         /**< VLAN ID value if used */
+    uint16_t ether_hdr_size; /**< Size of Ethernet header in packet for VLAN ID */
 
-        uint16_t pktSize; /**< Size of packet in bytes not counting FCS */
-        uint16_t pad0;
-    };
+    uint16_t pktSize; /**< Size of packet in bytes not counting FCS */
+    uint16_t pad0;
+};
 
-    typedef struct rte_mempool pktmbuf_t;
-    typedef struct rte_mempool mempool_t;
-    typedef struct vec vec_t;
+typedef struct rte_mempool pktmbuf_t;
+typedef struct rte_mempool mempool_t;
+typedef struct vec vec_t;
 
-    /**
-     * Push an integer value and set it as field @p name in the table at the top of the stack.
-     *
-     * @param L      Lua state.
-     * @param name   Field name in the table.
-     * @param value  Integer value to set.
-     */
-    static __inline__ void setf_integer(lua_State * L, const char *name, lua_Integer value)
-    {
-        lua_pushinteger(L, value);
-        lua_setfield(L, -2, name);
-    }
+/**
+ * Push an integer value and set it as field @p name in the table at the top of the stack.
+ *
+ * @param L      Lua state.
+ * @param name   Field name in the table.
+ * @param value  Integer value to set.
+ */
+static __inline__ void
+setf_integer(lua_State *L, const char *name, lua_Integer value)
+{
+    lua_pushinteger(L, value);
+    lua_setfield(L, -2, name);
+}
 
-    /**
-     * Push a C closure (with no upvalues) and set it as field @p name in the table at stack top.
-     *
-     * @param L     Lua state.
-     * @param name  Field name in the table.
-     * @param fn    C function to push as a closure.
-     */
-    static __inline__ void setf_function(lua_State * L, const char *name, lua_CFunction fn)
-    {
-        lua_pushcclosure(L, fn, 0);
-        lua_setfield(L, -2, name);
-    }
+/**
+ * Push a C closure (with no upvalues) and set it as field @p name in the table at stack top.
+ *
+ * @param L     Lua state.
+ * @param name  Field name in the table.
+ * @param fn    C function to push as a closure.
+ */
+static __inline__ void
+setf_function(lua_State *L, const char *name, lua_CFunction fn)
+{
+    lua_pushcclosure(L, fn, 0);
+    lua_setfield(L, -2, name);
+}
 
-    /**
-     * Push a NUL-terminated string and set it as field @p name in the table at stack top.
-     *
-     * @param L      Lua state.
-     * @param name   Field name in the table.
-     * @param value  String value to push.
-     */
-    static __inline__ void setf_string(lua_State * L, const char *name, const char *value)
-    {
-        lua_pushstring(L, value);
-        lua_setfield(L, -2, name);
-    }
+/**
+ * Push a NUL-terminated string and set it as field @p name in the table at stack top.
+ *
+ * @param L      Lua state.
+ * @param name   Field name in the table.
+ * @param value  String value to push.
+ */
+static __inline__ void
+setf_string(lua_State *L, const char *name, const char *value)
+{
+    lua_pushstring(L, value);
+    lua_setfield(L, -2, name);
+}
 
-    /**
-     * Push a length-delimited string and set it as field @p name in the table at stack top.
-     *
-     * @param L      Lua state.
-     * @param name   Field name in the table.
-     * @param value  String data to push (need not be NUL-terminated).
-     * @param len    Number of bytes in @p value.
-     */
-    static __inline__ void setf_stringLen(lua_State * L, const char *name, char *value, int len)
-    {
-        lua_pushlstring(L, value, len);
-        lua_setfield(L, -2, name);
-    }
+/**
+ * Push a length-delimited string and set it as field @p name in the table at stack top.
+ *
+ * @param L      Lua state.
+ * @param name   Field name in the table.
+ * @param value  String data to push (need not be NUL-terminated).
+ * @param len    Number of bytes in @p value.
+ */
+static __inline__ void
+setf_stringLen(lua_State *L, const char *name, char *value, int len)
+{
+    lua_pushlstring(L, value, len);
+    lua_setfield(L, -2, name);
+}
 
-    /**
-     * Push a light userdata pointer and set it as field @p name in the table at stack top.
-     *
-     * @param L      Lua state.
-     * @param name   Field name in the table.
-     * @param value  Pointer to push as light userdata.
-     */
-    static __inline__ void setf_udata(lua_State * L, const char *name, void *value)
-    {
-        lua_pushlightuserdata(L, value);
-        lua_setfield(L, -2, name);
-    }
+/**
+ * Push a light userdata pointer and set it as field @p name in the table at stack top.
+ *
+ * @param L      Lua state.
+ * @param name   Field name in the table.
+ * @param value  Pointer to push as light userdata.
+ */
+static __inline__ void
+setf_udata(lua_State *L, const char *name, void *value)
+{
+    lua_pushlightuserdata(L, value);
+    lua_setfield(L, -2, name);
+}
 
-    /**
-     * Read an integer field from the Lua table at stack index 3.
-     *
-     * @param L      Lua state (field is read from the table at index 3).
-     * @param field  Name of the integer field to retrieve.
-     * @return       Field value as uint32_t, or 0 if the field is absent or not an integer.
-     */
-    static __inline__ uint32_t getf_integer(lua_State * L, const char *field)
-    {
-        uint32_t value = 0;
+/**
+ * Read an integer field from the Lua table at stack index 3.
+ *
+ * @param L      Lua state (field is read from the table at index 3).
+ * @param field  Name of the integer field to retrieve.
+ * @return       Field value as uint32_t, or 0 if the field is absent or not an integer.
+ */
+static __inline__ uint32_t
+getf_integer(lua_State *L, const char *field)
+{
+    uint32_t value = 0;
 
-        lua_getfield(L, 3, field);
-        if (lua_isinteger(L, -1))
-            value = luaL_checkinteger(L, -1);
-        lua_pop(L, 1);
+    lua_getfield(L, 3, field);
+    if (lua_isinteger(L, -1))
+        value = luaL_checkinteger(L, -1);
+    lua_pop(L, 1);
 
-        return value;
-    }
+    return value;
+}
 
-    /**
-     * Read a string field from the Lua table at stack index 3.
-     *
-     * @param L      Lua state (field is read from the table at index 3).
-     * @param field  Name of the string field to retrieve.
-     * @return       Pointer to the Lua-managed string, or NULL if absent or not a string.
-     */
-    static __inline__ const char *getf_string(lua_State * L, const char *field)
-    {
-        const char *value = NULL;
+/**
+ * Read a string field from the Lua table at stack index 3.
+ *
+ * @param L      Lua state (field is read from the table at index 3).
+ * @param field  Name of the string field to retrieve.
+ * @return       Pointer to the Lua-managed string, or NULL if absent or not a string.
+ */
+static __inline__ const char *
+getf_string(lua_State *L, const char *field)
+{
+    const char *value = NULL;
 
-        lua_getfield(L, 3, field);
-        if (lua_isstring(L, -1))
-            value = luaL_checkstring(L, -1);
-        lua_pop(L, 1);
+    lua_getfield(L, 3, field);
+    if (lua_isstring(L, -1))
+        value = luaL_checkstring(L, -1);
+    lua_pop(L, 1);
 
-        return value;
-    }
+    return value;
+}
 
 #ifdef __cplusplus
 }

--- a/lib/lua/lua_dpdk.h
+++ b/lib/lua/lua_dpdk.h
@@ -27,8 +27,7 @@
 #include <lauxlib.h>
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #define LUA_DPDK_LIBNAME "dpdk"

--- a/lib/lua/lua_dpdk.h
+++ b/lib/lua/lua_dpdk.h
@@ -13,7 +13,7 @@
  *
  * Defines common structures (pkt_data), iteration macros (foreach_port),
  * argument validation helpers (validate_arg_count), and a set of
- * setf_*/getf_* inline functions for pushing and pulling values between
+ * setf_* and getf_* inline functions for pushing and pulling values between
  * C and Lua table fields.
  */
 

--- a/lib/lua/lua_utils.h
+++ b/lib/lua/lua_utils.h
@@ -85,8 +85,8 @@ static inline void
 l_message(const char *pname, const char *msg)
 {
     if (pname)
-        lua_writestringerror("%s: ", pname);
-    lua_writestringerror("%s\n", msg);
+        fprintf(stderr, "%s: ", pname);
+    fprintf(stderr, "%s\n", msg);
 }
 
 /**


### PR DESCRIPTION
Fix compilation errors with lua v5.5 and  gcc 15.2.1 on opensuse Tumbleweed. 

I compiled with:
```
meson setup -Dc_args="-march=x86-64-v3" -Denable_lua=true . x86_64-suse-linux
meson compile -C x86_64-suse-linux
```

I got two problems, 
1) one was that the multi line comment wasn't treated correctly
```
In file included from ../lib/lua/lua_dpdk.c:24:
../lib/lua/lua_dpdk.h:16:11: error: unknown type name ‘getf_’
   16 |  * setf_*/getf_* inline functions for pushing and pulling values between
      |           ^~~~~
```

2) `lua_writestringerror()`, `lua_writeline()` and `lua_writestring()` isn't available anymore.
```
In file included from ../lib/lua/lua_config.c:32:
../lib/lua/lua_utils.h: In function ‘l_message’:
../lib/lua/lua_utils.h:88:9: error: implicit declaration of function ‘lua_writestringerror’ [-Wimplicit-function-declaration]
   88 |         lua_writestringerror("%s: ", pname);
      |         ^~~~~~~~~~~~~~~~~~~~
../lib/lua/lua_config.c: In function ‘lua_create_instance’:
../lib/lua/lua_config.c:182:5: error: implicit declaration of function ‘lua_writestring’; did you mean ‘lua_putstring’? [-Wimplicit-function-declaration]
  182 |     lua_writestring(LUA_COPYRIGHT, strlen(LUA_COPYRIGHT));
      |     ^~~~~~~~~~~~~~~
      |     lua_putstring
../lib/lua/lua_config.c:183:5: error: implicit declaration of function ‘lua_writeline’; did you mean ‘lua_readline’? [-Wimplicit-function-declaration]
  183 |     lua_writeline();
      |     ^~~~~~~~~~~~~
      |     lua_readline
```
